### PR TITLE
chore(logger): restore stashed changes

### DIFF
--- a/scripts/kobong_logger.psm1
+++ b/scripts/kobong_logger.psm1
@@ -1,37 +1,53 @@
-﻿# kobong_logger v0.1 — robust process logging & classification (no color heuristics)
-# Exports: Invoke-KBProc, Remove-AnsiEscapes
+﻿# kobong_logger v0.2 — PS5/PS7 compatible (no ArgumentList)
 function Remove-AnsiEscapes {
   param([string]$s)
   if ($null -eq $s) { return '' }
-  return ($s -replace '\x1B\[[0-9;]*[A-Za-z]', '')
+  # strip ESC[… letter  + CR carriage-only lines
+  $t = ($s -replace '\x1B\[[0-9;]*[A-Za-z]', '')
+  return ($t -replace '\r(?!\n)', '') 
+}
+function Join-KBArgs {
+  param([string[]]$Args)
+  if (-not $Args) { return '' }
+  $qq = '"'
+  $out = foreach($a in $Args){
+    if ($a -match '[\s"$`^|&<>]') {
+      $escaped = $a -replace '"','\"'
+      "$qq$escaped$qq"
+    } else { $a }
+  }
+  ($out -join ' ')
 }
 function Invoke-KBProc {
   [CmdletBinding()]
   param(
     [Parameter(Mandatory)][string]$FilePath,
     [string[]]$ArgumentList = @(),
-    [string[]]$SuppressWarnPatterns = @('^warning:\s+in the working copy of'), # git warning 무시 예
-    [string[]]$ErrorPatterns = @('\bfatal\b', '\berror\b', '\bGH00\d+\b', '^X\s') # GH006 등
+    [string[]]$SuppressWarnPatterns = @('^warning:\s+in the working copy of'),
+    [string[]]$ErrorPatterns = @('\bfatal\b', '\berror\b', '\bGH00\d+\b', '^X\s')
   )
   $psi = [System.Diagnostics.ProcessStartInfo]::new()
   $psi.FileName = $FilePath
-  foreach($a in $ArgumentList){ [void]$psi.ArgumentList.Add($a) }
+  # PS5 호환: Arguments 문자열로 전달
+  $psi.Arguments = (Join-KBArgs -Args $ArgumentList)
   $psi.RedirectStandardOutput = $true
   $psi.RedirectStandardError  = $true
-  $psi.UseShellExecute = $false
-  $psi.CreateNoWindow = $true
+  $psi.UseShellExecute        = $false
+  $psi.CreateNoWindow         = $true
+
   $p = [System.Diagnostics.Process]::new()
   $p.StartInfo = $psi
   [void]$p.Start()
+
   $stdout = $p.StandardOutput.ReadToEnd()
   $stderr = $p.StandardError.ReadToEnd()
   $p.WaitForExit()
+
   $out = Remove-AnsiEscapes $stdout
   $err = Remove-AnsiEscapes $stderr
   $outLines = if ($out) { $out -split "`r?`n" } else { @() }
   $errLines = if ($err) { $err -split "`r?`n" } else { @() }
 
-  # 경고/에러 라인 분류(색상 무시, 내용 기반)
   $warn = @()
   foreach($ln in $errLines){
     if ($SuppressWarnPatterns | Where-Object { $ln -match $_ }) { continue }


### PR DESCRIPTION
﻿This PR restores the stashed edits to **kobong_logger.psm1** only.

- Scope: scripts/kobong_logger.psm1
- Excludes: other untracked files (to be reviewed/committed separately)

Safety:
- Single-intent commit
- No repo-wide line-ending churn
