### PR TITLE
chore: normalize EOLs via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,49 +1,38 @@
-* text=auto eol=lf
+﻿* text=auto eol=lf
 
-# Windows scripts (선호 스타일 명시)
-*.bat text eol=crlf
-*.cmd text eol=crlf
-
-# PowerShell/Unix scripts & yaml/md → LF
-*.ps1  text eol=lf
-*.psm1 text eol=lf
-*.psd1 text eol=lf
-*.sh   text eol=lf
-*.yml  text eol=lf
-*.yaml text eol=lf
-*.md   text eol=lf
-
-# Normalize line endings (LF default)
-*           text=auto eol=lf
-
-# Windows batch files keep CRLF
-*.bat       text eol=crlf
-*.cmd       text eol=crlf
-
-# PowerShell scripts ? LF? ?? (PS7/5.1 ?? OK)
-*.ps1       text eol=lf
-*.psm1      text eol=lf
-*.psd1      text eol=lf
-
-# Common text types
-*.sh        text eol=lf
-*.py        text eol=lf
-*.ts        text eol=lf
-*.tsx       text eol=lf
-*.js        text eol=lf
-*.jsx       text eol=lf
-*.json      text eol=lf
-*.yml       text eol=lf
-*.yaml      text eol=lf
-*.md        text eol=lf
-*.toml      text eol=lf
-*.ini       text eol=lf
-
-*.ps1 text eol=crlf
-*.sh  text eol=lf
+# Windows scripts
 *.ps1  text eol=crlf
 *.psm1 text eol=crlf
-*.psd1 text eol=crlf
-*.dsl  text eol=lf
+*.cmd  text eol=crlf
+*.bat  text eol=crlf
+
+# Unix scripts
+*.sh   text eol=lf
+
+# Data & configs
+*.yml  text eol=lf
+*.yaml text eol=lf
 *.json text eol=lf
-*.csv  text eol=lf
+*.md   text eol=lf
+*.ini  text eol=lf
+*.toml text eol=lf
+
+# Source
+*.ts   text eol=lf
+*.tsx  text eol=lf
+*.js   text eol=lf
+*.jsx  text eol=lf
+*.py   text eol=lf
+
+# Binaries
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.pdf  binary
+*.zip  binary
+*.7z   binary
+*.exe  binary
+*.dll  binary
+*.pdb  binary


### PR DESCRIPTION
﻿Normalize line endings and enforce consistent EOL policy via **.gitattributes**.

- Windows PowerShell scripts: CRLF
- Source/Configs: LF
- Binaries: binary

This removes recurring "CRLF will be replaced by LF" warnings.
