### PR TITLE
ci(release): run only on tags

### DIFF
--- a/.github/workflows/release-on-tag-ops.yml
+++ b/.github/workflows/release-on-tag-ops.yml
@@ -1,0 +1,22 @@
+# NO-SHELL
+name: Release on Tag (ops)
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create or update GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release create "$tag" --generate-notes || gh release edit "$tag" --latest


### PR DESCRIPTION
Add tag-only release workflow to avoid branch push failures.