### PR TITLE
chore(eol): enforce LF via .gitattributes; standardize /health (HTTP 200 JSON)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,23 +1,4 @@
-*           text eol=lf
-# Common text extensions (explicit, to defeat 'auto' misdetection):
-*.ps1       text eol=lf
-*.psm1      text eol=lf
-*.psd1      text eol=lf
-*.cmd       text eol=lf
-*.bat       text eol=lf
-*.sh        text eol=lf
-*.md        text eol=lf
-*.txt       text eol=lf
-*.json      text eol=lf
-*.yml       text eol=lf
-*.yaml      text eol=lf
-*.js        text eol=lf
-*.cjs       text eol=lf
-*.mjs       text eol=lf
-*.ts        text eol=lf
-*.tsx       text eol=lf
-*.jsx       text eol=lf
-*.css       text eol=lf
-*.scss      text eol=lf
-*.tsconfig  text eol=lf
-*.editorconfig text eol=lf
+* text=auto eol=lf
+*.mjs  text eol=lf
+*.ps1  text eol=lf
+*.cmd  text eol=crlf

--- a/scripts/health-server.mjs
+++ b/scripts/health-server.mjs
@@ -33,3 +33,4 @@ function gracefulExit(code=0){ try { server.close(()=>process.exit(code)); } cat
 process.on("SIGINT", ()=>gracefulExit(0));
 process.on("SIGTERM",()=>gracefulExit(0));
 
+

--- a/scripts/health-server.mjs
+++ b/scripts/health-server.mjs
@@ -1,0 +1,35 @@
+﻿import http from "node:http";
+import { URL } from "node:url";
+
+const PORT = Number(process.env.PORT || 8080);
+const startedAt = Date.now();
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (req.method === "GET" && url.pathname === "/health") {
+    const body = JSON.stringify({ status: "ok", ready: true, uptimeSec: Math.floor((Date.now() - startedAt) / 1000) });
+    res.writeHead(200, { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" });
+    res.end(body);
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/live") {
+    res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+    res.end("live");
+    return;
+  }
+  res.writeHead(404, { "content-type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify({ status: "not_found" }));
+});
+
+server.on("clientError", (err, socket) => { try { socket.end("HTTP/1.1 400 Bad Request\r\n\r\n"); } catch {} });
+server.on("error", (err) => { console.error("[health] server error:", err?.message || err); process.exitCode = 1; });
+
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`[health] listening on http://localhost:${PORT}/health (pid=${process.pid})`);
+  console.log(JSON.stringify({ timestamp: new Date().toISOString(), module: "app", action: "bootstrap", outcome: "ok" }));
+});
+
+function gracefulExit(code=0){ try { server.close(()=>process.exit(code)); } catch { process.exit(code); } }
+process.on("SIGINT", ()=>gracefulExit(0));
+process.on("SIGTERM",()=>gracefulExit(0));
+


### PR DESCRIPTION
This PR enforces LF endings and introduces a stable /health endpoint:

- .gitattributes: LF defaults for repo, explicit rules for .mjs/.ps1/.cmd
- scripts/health-server.mjs: returns HTTP 200 JSON {status:'ok', ready:true}

CI: expect 'Release Gate (auto)' to run and pass.