### PR TITLE
docs: CHANGELOG for v0.0.6 + guard-logs-ignored CI

### DIFF
--- a/.github/workflows/guard-logs-ignored.yml
+++ b/.github/workflows/guard-logs-ignored.yml
@@ -1,0 +1,13 @@
+name: guard-logs-ignored
+on: [pull_request]
+jobs:
+  no-tracked-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure no tracked files under logs/
+        run: |
+          if git ls-files -- logs/ | grep .; then
+            echo "Tracked files under logs/ found!"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## v0.0.6 — 2025-09-15
+
+### Commits
+- 24bb8eb2	chore: ignore logs/ (prevent file locks during pulls) (#31)
+- 838b7b67	recover: local stash 20250915-145919 (#29)
+- c27acfd0	recover: local stash 20250915-151706 (#27)
+- cc8bc855	recover: local stash 20250915-151234 (#30)
+- 7924df27	recover: local stash 20250915-151234 (#28)
+- 8570c6bc	recover: local stash 20250915-152137 (#26)
+- 7d11504e	ops: fix contracts-status (no PS interpolation, tolerant) (#25)
+- 16229887	docs: add status dashboard (docs/status.html) (#24)
+- f6e1b058	docs: add health badge to README (#23)
+- 407b80d2	ops: badges workflow (local health ??SVG) (#22)
+- a5491115	ops: add health monitor (auto-heal) (#21)
+- ce36aa8b	ops: add health monitor (auto-heal) (#20)
+- 5ea29eeb	chore(eol): enforce LF via .gitattributes; standardize /health (HTTP 200 JSON) (#19)
+- 9da5289d	docs(readme): add release badge (#18)
+- 67a1fa9b	ci(release): make tag release robust (GH_TOKEN + manual input) (#17)
+- 9ead23b2	ci(release): run only on tags (#16)
+- df47946c	chore(release): seed CHANGELOG for v0.1.0 (#15)
+- 758493f3	chore(gitignore): ignore ops artifacts (#14)
+- 1cc25372	docs(ops): add ops-experience-log entry (#13)
+- ec6780cf	docs(ops): add mini TOC + README ops links (#12)
+- dc945094	chore(governance): assert GPT-5 lead mode (state) (#11)
+- f8766fc5	chore(eol): enforce LF & renormalize line endings (#9)
+- e715b50e	ci/klc smoke (#8)
+- 1b8e557e	chore: add ignore rules + track base configs/scripts (#7)
+- 790096b2	ci: add EOL Guard (CRLF blocker) (#6)
+- 949cd24f	chore: normalize EOLs via .gitattributes (#5)
+- df9da45c	chore(logger): restore stashed changes (#4)
+- 34990308	ci: Release Gate (single required check) (#3)
+- 74ea8089	chore: add kobong_logger + Node20 CI safe edits (+ .gitattributes) (#2)
+- e5f93d0c	docs: add README badges (Contracts CI, Release Gate) (#1)
+- e40e79ef	ci: set upload-artifact retention-days=14 across workflows
+- 0f9ae9eb	chore: tidy repo (.gitignore for backups/logs)
+
+


### PR DESCRIPTION
This PR adds the v0.0.6 changelog and a guard workflow that fails if any files under \logs/\ are tracked.

- CHANGELOG updated for v0.0.6 (2025-09-15)
- Add .github/workflows/guard-logs-ignored.yml