### PR TITLE
ci: enforce EOL via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.ps1 text eol=lf
+*.cmd text eol=crlf


### PR DESCRIPTION
Add/normalize .gitattributes to enforce LF/CRLF. Prevents CRLF noise and Windows shell issues.