### PR TITLE
ci: bridge guard to required status context

### DIFF
--- a/.github/workflows/guard-logs-ignored.yml
+++ b/.github/workflows/guard-logs-ignored.yml
@@ -1,13 +1,35 @@
 name: guard-logs-ignored
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   no-tracked-logs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Ensure no tracked files under logs/
+        id: guard
         run: |
           if git ls-files -- logs/ | grep .; then
             echo "Tracked files under logs/ found!"
             exit 1
           fi
+      - name: Bridge to required status context
+        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then state=success; else state=failure; fi
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          ctx="guard-logs-ignored/no-tracked-logs"
+          desc="guard-logs-ignored: $state"
+          target="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/statuses/$sha" \
+            -d "{\"state\":\"$state\",\"context\":\"$ctx\",\"description\":\"$desc\",\"target_url\":\"$target\"}" \
+            >/dev/null


### PR DESCRIPTION
Set commit status 'guard-logs-ignored/no-tracked-logs' from workflow result.