### PR TITLE
chore(release): v0.1.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,53 @@
+# v0.1.4 — 2025-09-17
+
+* ee44cfa8 ops(hardening): repo safety pack (hooks/ignore/logs guard) (#57) (dh1293-hub, 2025-09-17)
+* bd6b31a0 test: guard-logs-ignored smoke (#56) (dh1293-hub, 2025-09-17)
+* 0dc2caa2 ci: add guard-logs-ignored & Release Gate (auto) (#55) (dh1293-hub, 2025-09-17)
+* 83d00f5d chore(ci): ensure ignore rules (!logs/.gitkeep, *.bak-*) (#54) (dh1293-hub, 2025-09-16)
+* b9a9fc03 chore: branch-protection smoke (20250915-191627) (#36) (dh1293-hub, 2025-09-16)
+* 2d9818c1 chore(ci): ensure ignore rules (!logs/.gitkeep, *.bak-*) (#53) (dh1293-hub, 2025-09-16)
+* 70e96586 ci: bridge guard to required status context (#35) (dh1293-hub, 2025-09-15)
+* a51e15f6 ci: enforce EOL via .gitattributes (#34) (dh1293-hub, 2025-09-15)
+* 403f9f07 docs: CHANGELOG for v0.0.6 + guard-logs-ignored CI (#32) (dh1293-hub, 2025-09-15)
+* 24bb8eb2 chore: ignore logs/ (prevent file locks during pulls) (#31) (dh1293-hub, 2025-09-15)
+* 838b7b67 recover: local stash 20250915-145919 (#29) (dh1293-hub, 2025-09-15)
+* c27acfd0 recover: local stash 20250915-151706 (#27) (dh1293-hub, 2025-09-15)
+* cc8bc855 recover: local stash 20250915-151234 (#30) (dh1293-hub, 2025-09-15)
+* 7924df27 recover: local stash 20250915-151234 (#28) (dh1293-hub, 2025-09-15)
+* 8570c6bc recover: local stash 20250915-152137 (#26) (dh1293-hub, 2025-09-15)
+* 7d11504e ops: fix contracts-status (no PS interpolation, tolerant) (#25) (dh1293-hub, 2025-09-15)
+* 16229887 docs: add status dashboard (docs/status.html) (#24) (dh1293-hub, 2025-09-15)
+* f6e1b058 docs: add health badge to README (#23) (dh1293-hub, 2025-09-15)
+* 407b80d2 ops: badges workflow (local health ??SVG) (#22) (dh1293-hub, 2025-09-15)
+* a5491115 ops: add health monitor (auto-heal) (#21) (dh1293-hub, 2025-09-15)
+* ce36aa8b ops: add health monitor (auto-heal) (#20) (dh1293-hub, 2025-09-15)
+* 5ea29eeb chore(eol): enforce LF via .gitattributes; standardize /health (HTTP 200 JSON) (#19) (dh1293-hub, 2025-09-15)
+* 9da5289d docs(readme): add release badge (#18) (dh1293-hub, 2025-09-14)
+* 67a1fa9b ci(release): make tag release robust (GH_TOKEN + manual input) (#17) (dh1293-hub, 2025-09-14)
+* 9ead23b2 ci(release): run only on tags (#16) (dh1293-hub, 2025-09-14)
+* df47946c chore(release): seed CHANGELOG for v0.1.0 (#15) (dh1293-hub, 2025-09-14)
+* 758493f3 chore(gitignore): ignore ops artifacts (#14) (dh1293-hub, 2025-09-14)
+* 1cc25372 docs(ops): add ops-experience-log entry (#13) (dh1293-hub, 2025-09-14)
+* ec6780cf docs(ops): add mini TOC + README ops links (#12) (dh1293-hub, 2025-09-14)
+* dc945094 chore(governance): assert GPT-5 lead mode (state) (#11) (dh1293-hub, 2025-09-14)
+* f8766fc5 chore(eol): enforce LF & renormalize line endings (#9) (dh1293-hub, 2025-09-14)
+* e715b50e ci/klc smoke (#8) (dh1293-hub, 2025-09-13)
+* 1b8e557e chore: add ignore rules + track base configs/scripts (#7) (dh1293-hub, 2025-09-13)
+* 790096b2 ci: add EOL Guard (CRLF blocker) (#6) (dh1293-hub, 2025-09-13)
+* 949cd24f chore: normalize EOLs via .gitattributes (#5) (dh1293-hub, 2025-09-13)
+* df9da45c chore(logger): restore stashed changes (#4) (dh1293-hub, 2025-09-13)
+* 34990308 ci: Release Gate (single required check) (#3) (dh1293-hub, 2025-09-13)
+* 74ea8089 chore: add kobong_logger + Node20 CI safe edits (+ .gitattributes) (#2) (dh1293-hub, 2025-09-13)
+* e5f93d0c docs: add README badges (Contracts CI, Release Gate) (#1) (dh1293-hub, 2025-09-13)
+* e40e79ef ci: set upload-artifact retention-days=14 across workflows (Han Minsu, 2025-09-12)
+* 0f9ae9eb chore: tidy repo (.gitignore for backups/logs) (Han Minsu, 2025-09-12)
+* c2478b15 ci(dsl): CI-safe fallback for DSL demo (mock result when missing) (Han Minsu, 2025-09-12)
+* ae8e4ff8 ci: disable legacy release workflows (enforce Release Gate only) (Han Minsu, 2025-09-12)
+* bf816f2d ci(contracts): harden deps + pytest + diagnostics (Han Minsu, 2025-09-12)
+* 9fd59218 ci(contracts): ensure pytest and use python -m pytest (Han Minsu, 2025-09-12)
+* be087aab ci: add Release Gate (auto) triggered by Contracts CI/variants (Han Minsu, 2025-09-12)
+
+
 # Changelog
 
 ## v0.0.6 — 2025-09-15
@@ -35,5 +85,6 @@
 - e5f93d0c	docs: add README badges (Contracts CI, Release Gate) (#1)
 - e40e79ef	ci: set upload-artifact retention-days=14 across workflows
 - 0f9ae9eb	chore: tidy repo (.gitignore for backups/logs)
+
 
 


### PR DESCRIPTION
- Apply CHANGELOG for v0.1.4
- Created due to protected main (GH006)