### PR TITLE
docs(readme): fix badge link (v0.1.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-[![Release](https://img.shields.io/github/v/release/dh1293-hub/kobong-orchestrator?display_name=tag&sort=semver)](https://github.com/dh1293-hub/kobong-orchestrator/releases/tag/v0\.1\.10)
+[![Release](https://img.shields.io/github/v/release/dh1293-hub/kobong-orchestrator?display_name=tag&sort=semver)](https://github.com/dh1293-hub/kobong-orchestrator/releases/tag/v0.1.10)
 
 


### PR DESCRIPTION
Replace 'v0\\.1\\.10' with 'v0.1.10' in release badge link.