### PR TITLE
ci(guard): add Guard README Badge workflow

### DIFF
--- a/.github/workflows/guard-readme-badge.yml
+++ b/.github/workflows/guard-readme-badge.yml
@@ -1,0 +1,24 @@
+name: Guard README Badge
+on:
+  pull_request:
+    paths:
+      - README.md
+      - .github/workflows/**
+      - scripts/g5/**
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if escaped version is present (e.g. v0\.1\.11)
+        run: |
+          if grep -qE 'releases/tag/v[0-9]+\.[0-9]+\.[0-9]+\\\.' README.md; then
+            echo "ERROR: Escaped version found in README badge link."
+            exit 1
+          fi
+      - name: Ensure a clean version link exists
+        run: |
+          if ! grep -qE 'releases/tag/v[0-9]+\.[0-9]+\.[0-9]+' README.md; then
+            echo "ERROR: No release tag link found in README."
+            exit 1
+          fi


### PR DESCRIPTION
Fail PR if README badge link contains escaped version or lacks clean link.