### PR TITLE
fix(g5): wrapper v2 — discard to $null (robust)

### DIFF
--- a/docs/Kobong-Weekly-Housekeeping.xml
+++ b/docs/Kobong-Weekly-Housekeeping.xml
@@ -11,7 +11,7 @@
   </Principals>
   <Settings>
     <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
-    <StopIfGoingOnBatteries>true</StopIfGoingOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
     <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
     <StartWhenAvailable>true</StartWhenAvailable>
     <IdleSettings>

--- a/scripts/g5/housekeeping-weekly-run.ps1
+++ b/scripts/g5/housekeeping-weekly-run.ps1
@@ -112,9 +112,8 @@ try {
   }
 
   # Flush remaining lines
-  $ = Flush-Queue $stdoutQ 'child'
-  $ = Flush-Queue $stderrQ 'child-err'
-
+ = Flush-Queue $stdoutQ 'child'
+ = Flush-Queue $stderrQ 'child-err'
   Write-Host "`r`n[exit] code=$($proc.ExitCode)"
   exit $proc.ExitCode
 }


### PR DESCRIPTION
Replace invalid $ = Flush-Queue with $null = ... for both stdout/stderr; resilient regex.