### PR TITLE
ci(weekly-smoke): fix git identity for tag push

### DIFF
--- a/.github/workflows/weekly-auto-release-smoke.yml
+++ b/.github/workflows/weekly-auto-release-smoke.yml
@@ -18,6 +18,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name  "github-actions[bot]"
           git fetch --tags
           base="v0.0."; i=0
           while git tag -l | grep -qx "${base}${i}"; do i=$((i+1)); done
@@ -34,9 +36,13 @@ jobs:
         run: |
           set -euo pipefail
           tag="${TAG}"
+          ok=0
           for _ in $(seq 1 36); do
-            if gh release view "$tag" >/dev/null 2>&1; then break; fi
+            if gh release view "$tag" >/dev/null 2>&1; then ok=1; break; fi
             sleep 5
           done
-          gh release delete "$tag" -y || true
+          if [ "$ok" -ne 1 ]; then
+            echo "No release found for $tag; proceeding to cleanup."
+          fi
+          gh release delete "$tag" -y >/dev/null 2>&1 || true
           git push origin ":refs/tags/$tag" || true


### PR DESCRIPTION
Set local git user.name/email so 'git tag -a' works on runners. Also tolerate missing release.