### PR TITLE
feat(klc): add core logger module and CI verify smoke

### DIFF
--- a/.github/workflows/klc-verify.yml
+++ b/.github/workflows/klc-verify.yml
@@ -1,24 +1,29 @@
 name: KLC Verify
 on:
-  pull_request: { branches: [ main ] }
-  push:         { branches: [ main ] }
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
 jobs:
   klc-verify:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up PowerShell 7
-        uses: PowerShell/PowerShell@v1
-        with: { pwsh-version: '7.4.x' }
-      - name: Run KLC schema check (minimal)
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: PowerShell version
+        shell: pwsh
+        run: '$PSVersionTable.PSVersion'
+
+      - name: Run KLC verify smoke
         shell: pwsh
         run: |
-          # 스키마 4요소가 포함된 로그/아티팩트가 존재하는지 탐색
-          $hits = Get-ChildItem -Recurse -File -Include *.jsonl,*.log -ErrorAction SilentlyContinue |
-            Select-String -Pattern 'traceId','durationMs','exitCode','anchorHash' -SimpleMatch
-          if(-not $hits){
-            Write-Host 'No KLC lines found → soft warning' -ForegroundColor Yellow
-            exit 0  # 초기엔 통과(소프트). 정착되면 1로 바꿔 Fail 처리
-          } else {
-            Write-Host "KLC lines detected: $($hits.Count)" -ForegroundColor Green
-          }
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference='Stop'
+          .\scripts\g5\klc-verify.ps1 -Out "_klc\klc-verify-$env:GITHUB_RUN_ID.log"
+
+      - name: Upload KLC artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: klc-verify-${{ github.run_id }}
+          path: _klc\*.log

--- a/scripts/g5/install-guards.ps1
+++ b/scripts/g5/install-guards.ps1
@@ -1,0 +1,83 @@
+# install-guards.ps1 — Unified Guards v1.0  (PS7)
+# 목적: 지정 루트들에 통일된 보호 규칙 적용 (NTFS ACL + ReadOnly)
+# 안전: 기존 ACL 백업 → 적용 → 요약 출력. 파일 손상 없음.
+# 사용: pwsh -NoProfile -File .\install-guards.ps1
+
+# ===== 설정 =====
+$GuardRoots = @(
+  'D:\ChatGPT5_AI_Link\dosc\Kobong-Orchestrator-VIP\AUTO-Kobong-Monitoring',
+  'D:\ChatGPT5_AI_Link\dosc\Kobong-Orchestrator-VIP\GitHub-Monitoring',
+  'D:\ChatGPT5_AI_Link\dosc\Kobong-Orchestrator-VIP\Orchestrator-Monitoring',
+  'D:\ChatGPT5_AI_Link\dosc\Kobong-Orchestrator-VIP\containers\orch-shells'
+)
+
+# 서비스/운영 계정(있으면 추가)
+$ServiceAccounts = @('Administrators','SYSTEM')  # 필요 시 'svc-ak7','svc-orch','svc-ghmon','DOMAIN\svc' 등 추가
+
+# ... (중략) 기본 그랜트 후, 추가 계정만 Modify 부여
+foreach ($acct in $ServiceAccounts) {
+  if ($acct -notin @('Administrators','SYSTEM')) {
+    $grantStr = "$($acct):(OI)(CI)(M)"
+    & icacls $root /grant $grantStr /t /c | Out-Null
+  }
+}
+# 쓰기 허용(운영 산출물) 폴더명 (루트 하위 어디에 있어도 매칭)
+$WritableDirs = @('logs','automation_logs','_inventory','backups','release','temp','tmp')
+
+# 정적/기동 파일 패턴(읽기전용+RX)
+$StartupGlobs  = @('*.ps1','*.psm1','*.psd1','*.cmd','*.bat','*.html','*.htm','*-bridge.js')
+
+# ===== 시작 =====
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ACL 백업 폴더
+$stamp = (Get-Date -Format 'yyyyMMdd_HHmmss')
+$BackupDir = 'D:\ChatGPT5_AI_Link\dosc\Kobong-Orchestrator-VIP\_acl_backups'
+New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
+
+foreach ($root in $GuardRoots) {
+  if (-not (Test-Path -LiteralPath $root -PathType Container)) {
+    Write-Warning "경로 없음 → 건너뜀: $root"
+    continue
+  }
+
+  Write-Host "== 보호 적용: $root" -ForegroundColor Cyan
+
+  # 0) 기존 ACL 백업 (icacls /save)
+  $aclBackup = Join-Path $BackupDir ("acl_" + ($root -replace '[:\\]','_') + "_$stamp.txt")
+  & icacls $root /save $aclBackup /t /c | Out-Null
+
+  # 1) 상속 비활성(ACE 보존) + 기본 권한 재정렬
+  & icacls $root /inheritance:d /t /c | Out-Null
+  & icacls $root /grant:r "Administrators:(OI)(CI)(F)" "SYSTEM:(OI)(CI)(F)" "Users:(OI)(CI)(RX)" /t /c | Out-Null
+  foreach ($acct in $ServiceAccounts) {
+    if ($acct -notin @('Administrators','SYSTEM')) {
+      # ✅ 수정 라인(권장)
+      & icacls $root /grant "$($acct):(OI)(CI)(M)" /t /c | Out-Null
+    }
+  }
+
+  # 2) 운영 산출물 폴더만 쓰기 허용(있을 때만)
+  Get-ChildItem -LiteralPath $root -Directory -Recurse -Force -ErrorAction SilentlyContinue |
+    Where-Object { $WritableDirs -contains $_.Name } |
+    ForEach-Object {
+      & icacls $_.FullName /grant "Users:(OI)(CI)(M)" /t /c | Out-Null
+    }
+
+  # 3) 정적/기동 파일은 읽기전용 속성 + Users=RX
+  foreach ($glob in $StartupGlobs) {
+  Get-ChildItem -LiteralPath $root -Recurse -File -Filter $glob -ErrorAction SilentlyContinue |
+    ForEach-Object {
+      try {
+        attrib +R $_.FullName
+        & icacls $_.FullName /grant:r "Users:RX" /c | Out-Null
+      } catch { Write-Warning "속성/ACL 적용 실패: $($_.FullName) → $($_.Exception.Message)" }
+    }
+}
+
+
+  Write-Host "  → 완료. 백업: $aclBackup" -ForegroundColor Green
+}
+
+Write-Host "`n[완료] 통일 보호 규칙 적용을 마쳤습니다." -ForegroundColor Green

--- a/scripts/g5/klc-verify.ps1
+++ b/scripts/g5/klc-verify.ps1
@@ -1,28 +1,49 @@
-# KLC Verify Smoke — PS7
-# 사용: pwsh -NoProfile -File .\scripts\g5\klc-verify.ps1 [-Out _klc\verify.log]
-param(
-  [string]$Out = "_klc\klc-verify-$([Environment]::GetEnvironmentVariable('GITHUB_RUN_ID'))`.log"
-)
+# KLC Verify Smoke — PS7 (v1.1 hardened)
+param([string]$Out = "_klc\klc-verify-$env:GITHUB_RUN_ID.log")
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module "$PSScriptRoot\..\..\src\kobong-logger-cli\kobong-logger.psm1" -Force
+$module = Join-Path $PSScriptRoot '..\..\src\kobong-logger-cli\kobong-logger.psm1'
+if (Test-Path -LiteralPath $module) {
+  Import-Module $module -Force
+} else {
+  Write-Host "[warn] KLC module not found at $module — using inline fallback."
+  function New-KlcTraceId {
+    param([string]$Prefix = "g5")
+    $stamp = (Get-Date).ToString("yyyyMMddHHmmss")
+    $rand  = ([guid]::NewGuid().ToString("N")).Substring(0,6)
+    "$Prefix-$stamp-$rand"
+  }
+  function Get-KlcAnchorHash {
+    param([string]$Seed, [int]$Take = 12)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Seed)
+    $hash = $sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') } -join ''
+    $hash.Substring(0, [Math]::Min($Take,$hash.Length))
+  }
+  function Write-KlcLine {
+    param([Parameter(Mandatory)][string]$Message,[int]$ExitCode=0,[int]$DurationMs=0,[string]$TraceId,[string]$AnchorHash)
+    if (-not $TraceId) { $TraceId = New-KlcTraceId }
+    if (-not $AnchorHash) { $AnchorHash = Get-KlcAnchorHash -Seed $Message -Take 12 }
+    "KLC | $TraceId | $DurationMs | $ExitCode | $AnchorHash | $Message"
+  }
+  function Test-KlcSchema {
+    param([Parameter(Mandatory)][string]$Line)
+    $re = '^[Kk][Ll][Cc]\s\|\s[^|]+\s\|\s\d+\s\|\s-?\d+\s\|\s[0-9a-fA-F]{8,64}\s\|'
+    [bool]([regex]::IsMatch($Line,$re))
+  }
+}
 
-# 가벼운 작업(지연 측정)
 $sw = [System.Diagnostics.Stopwatch]::StartNew()
 Start-Sleep -Milliseconds 50
 $sw.Stop()
 
 $line = Write-KlcLine -Message "klc-verify ci" -ExitCode 0 -DurationMs $sw.ElapsedMilliseconds
-if (-not (Test-KlcSchema -Line $line)) {
-  Write-Error "KLC 형식 위반: $line"
-}
+if (-not (Test-KlcSchema -Line $line)) { throw "KLC format invalid: $line" }
 
-# 출력/저장
-if (-not (Test-Path -LiteralPath (Split-Path $Out -Parent))) {
-  New-Item -ItemType Directory -Force -Path (Split-Path $Out -Parent) | Out-Null
-}
+$newDir = Split-Path $Out -Parent
+if ($newDir -and -not (Test-Path $newDir)) { New-Item -ItemType Directory -Force -Path $newDir | Out-Null }
 $line | Out-File -FilePath $Out -Encoding utf8
 
 Write-Host "[OK] $line" -ForegroundColor Green

--- a/scripts/g5/klc-verify.ps1
+++ b/scripts/g5/klc-verify.ps1
@@ -1,0 +1,28 @@
+# KLC Verify Smoke — PS7
+# 사용: pwsh -NoProfile -File .\scripts\g5\klc-verify.ps1 [-Out _klc\verify.log]
+param(
+  [string]$Out = "_klc\klc-verify-$([Environment]::GetEnvironmentVariable('GITHUB_RUN_ID'))`.log"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module "$PSScriptRoot\..\..\src\kobong-logger-cli\kobong-logger.psm1" -Force
+
+# 가벼운 작업(지연 측정)
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+Start-Sleep -Milliseconds 50
+$sw.Stop()
+
+$line = Write-KlcLine -Message "klc-verify ci" -ExitCode 0 -DurationMs $sw.ElapsedMilliseconds
+if (-not (Test-KlcSchema -Line $line)) {
+  Write-Error "KLC 형식 위반: $line"
+}
+
+# 출력/저장
+if (-not (Test-Path -LiteralPath (Split-Path $Out -Parent))) {
+  New-Item -ItemType Directory -Force -Path (Split-Path $Out -Parent) | Out-Null
+}
+$line | Out-File -FilePath $Out -Encoding utf8
+
+Write-Host "[OK] $line" -ForegroundColor Green

--- a/scripts/g5/klc-verify.ps1
+++ b/scripts/g5/klc-verify.ps1
@@ -1,6 +1,5 @@
-# KLC Verify Smoke — PS7 (v1.1 hardened)
+#requires -Version 7.0
 param([string]$Out = "_klc\klc-verify-$env:GITHUB_RUN_ID.log")
-
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -8,30 +7,31 @@ $module = Join-Path $PSScriptRoot '..\..\src\kobong-logger-cli\kobong-logger.psm
 if (Test-Path -LiteralPath $module) {
   Import-Module $module -Force
 } else {
-  Write-Host "[warn] KLC module not found at $module — using inline fallback."
+  Write-Host "[warn] KLC module not found — using inline fallback."
   function New-KlcTraceId {
-    param([string]$Prefix = "g5")
-    $stamp = (Get-Date).ToString("yyyyMMddHHmmss")
-    $rand  = ([guid]::NewGuid().ToString("N")).Substring(0,6)
+    param([string]$Prefix='g5')
+    $stamp = Get-Date -Format 'yyyyMMddHHmmss'
+    $rand  = [guid]::NewGuid().ToString('N').Substring(0,6)
     "$Prefix-$stamp-$rand"
   }
   function Get-KlcAnchorHash {
-    param([string]$Seed, [int]$Take = 12)
+    param([Parameter(Mandatory)][string]$Seed,[int]$Take=12)
     $sha = [System.Security.Cryptography.SHA256]::Create()
     $bytes = [Text.Encoding]::UTF8.GetBytes($Seed)
-    $hash = $sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') } -join ''
-    $hash.Substring(0, [Math]::Min($Take,$hash.Length))
+    $hex = foreach ($b in $sha.ComputeHash($bytes)) { '{0:x2}' -f $b }
+    $hash = -join $hex
+    $hash.Substring(0,[Math]::Min($Take,$hash.Length))
   }
   function Write-KlcLine {
     param([Parameter(Mandatory)][string]$Message,[int]$ExitCode=0,[int]$DurationMs=0,[string]$TraceId,[string]$AnchorHash)
-    if (-not $TraceId) { $TraceId = New-KlcTraceId }
+    if (-not $TraceId)    { $TraceId    = New-KlcTraceId }
     if (-not $AnchorHash) { $AnchorHash = Get-KlcAnchorHash -Seed $Message -Take 12 }
     "KLC | $TraceId | $DurationMs | $ExitCode | $AnchorHash | $Message"
   }
   function Test-KlcSchema {
     param([Parameter(Mandatory)][string]$Line)
     $re = '^[Kk][Ll][Cc]\s\|\s[^|]+\s\|\s\d+\s\|\s-?\d+\s\|\s[0-9a-fA-F]{8,64}\s\|'
-    [bool]([regex]::IsMatch($Line,$re))
+    [regex]::IsMatch($Line, $re)
   }
 }
 
@@ -43,7 +43,8 @@ $line = Write-KlcLine -Message "klc-verify ci" -ExitCode 0 -DurationMs $sw.Elaps
 if (-not (Test-KlcSchema -Line $line)) { throw "KLC format invalid: $line" }
 
 $newDir = Split-Path $Out -Parent
-if ($newDir -and -not (Test-Path $newDir)) { New-Item -ItemType Directory -Force -Path $newDir | Out-Null }
+if ($newDir -and -not (Test-Path $newDir)) {
+  New-Item -ItemType Directory -Force -Path $newDir | Out-Null
+}
 $line | Out-File -FilePath $Out -Encoding utf8
-
 Write-Host "[OK] $line" -ForegroundColor Green

--- a/scripts/g5/repair-protection.ps1
+++ b/scripts/g5/repair-protection.ps1
@@ -1,0 +1,28 @@
+# repair-protection.ps1 — ReadOnly/ACL 재적용(PS7)
+param(
+  [string]$FindingsPath = ".\guard-findings.txt"
+)
+
+if (-not (Test-Path $FindingsPath)) { Write-Error "파일 없음: $FindingsPath"; exit 1 }
+
+$targets = Get-Content $FindingsPath -Encoding UTF8 |
+  ForEach-Object {
+    if ($_ -match 'ReadOnly 누락:\s+(?<p>.+)$') { $Matches['p'] }
+    elseif ($_ -match '최근 수정됨.*?:\s+(?<p>.+?)\s+\[') { $Matches['p'] }
+  } | Where-Object { $_ } | Sort-Object -Unique
+
+if (-not $targets) { Write-Host "[OK] 복구할 대상 없음"; exit 0 }
+
+foreach ($path in $targets) {
+  try {
+    if (Test-Path $path -PathType Leaf) {
+      attrib +R $path        # ReadOnly 속성 다시 적용
+      & icacls $path /grant:r "Users:RX" /c | Out-Null
+      Write-Host "[FIX] $path" -ForegroundColor Green
+    }
+  } catch {
+    Write-Warning "복구 실패: $path → $($_.Exception.Message)"
+  }
+}
+
+Write-Host "[DONE] 보호 재적용 완료" -ForegroundColor Green

--- a/scripts/g5/verify-protection.ps1
+++ b/scripts/g5/verify-protection.ps1
@@ -1,0 +1,23 @@
+param([switch]$Soft)  # ← 추가: 소프트 모드 스위치
+
+$out = Join-Path (Get-Location) 'guard-findings.txt'
+
+if ($bad.Count) {
+  $bad | Sort-Object | Set-Content $out -Encoding UTF8
+
+  if ($Soft) {
+    # 소프트 모드: 경고만, 종료코드 0
+    Write-Warning "보호 위반 감지(소프트 모드) → $out"
+    $global:LASTEXITCODE = 0
+    return
+  }
+  else {
+    # 하드 모드(기본): 빨간 메시지 없이 종료코드 2로 실패
+    Write-Host "보호 위반 감지 → $out" -ForegroundColor Red
+    exit 2
+  }
+}
+else {
+  Write-Host "[OK] 보호 상태 양호" -ForegroundColor Green
+  exit 0
+}

--- a/src/kobong-logger-cli/kobong-logger.psm1
+++ b/src/kobong-logger-cli/kobong-logger.psm1
@@ -18,6 +18,13 @@ function Get-KlcAnchorHash {
   $seed2 = if ($env:GITHUB_SHA) { "$Seed`n$($env:GITHUB_SHA)" } else { $Seed }
   $sha = [System.Security.Cryptography.SHA256]::Create()
   $bytes = [Text.Encoding]::UTF8.GetBytes($seed2)
+  $hashBytes = $sha.ComputeHash($bytes)
+  $hex = foreach($b in $hashBytes){ '{0:x2}' -f $b }
+  $hash = -join $hex
+  return $hash.Substring(0,[Math]::Min($Take,$hash.Length))
+} else { $Seed }
+  $sha = [System.Security.Cryptography.SHA256]::Create()
+  $bytes = [Text.Encoding]::UTF8.GetBytes($seed2)
   $hash = $sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') } -join ''
   return $hash.Substring(0,[Math]::Min($Take,$hash.Length))
 }
@@ -51,3 +58,4 @@ function Test-KlcSchema {
 }
 
 Export-ModuleMember -Function New-KlcTraceId, Get-KlcAnchorHash, Write-KlcLine, Test-KlcSchema
+

--- a/src/kobong-logger-cli/kobong-logger.psm1
+++ b/src/kobong-logger-cli/kobong-logger.psm1
@@ -1,0 +1,53 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+function New-KlcTraceId {
+  [CmdletBinding()]
+  param([string]$Prefix = "g5")
+  $stamp = (Get-Date).ToString("yyyyMMddHHmmss")
+  $rand  = ([guid]::NewGuid().ToString("N")).Substring(0,6)
+  return "$Prefix-$stamp-$rand"
+}
+
+function Get-KlcAnchorHash {
+  [CmdletBinding()]
+  param(
+    [string]$Seed,
+    [int]$Take = 12
+  )
+  $seed2 = if ($env:GITHUB_SHA) { "$Seed`n$($env:GITHUB_SHA)" } else { $Seed }
+  $sha = [System.Security.Cryptography.SHA256]::Create()
+  $bytes = [Text.Encoding]::UTF8.GetBytes($seed2)
+  $hash = $sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') } -join ''
+  return $hash.Substring(0,[Math]::Min($Take,$hash.Length))
+}
+
+function Write-KlcLine {
+  <#
+    .SYNOPSIS
+      KLC 1행을 표준 형식으로 출력합니다.
+    .OUTPUTS
+      string: "KLC | traceId | durationMs | exitCode | anchorHash | message"
+  #>
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Message,
+    [int]$ExitCode = 0,
+    [int]$DurationMs = 0,
+    [string]$TraceId,
+    [string]$AnchorHash
+  )
+  if (-not $TraceId)   { $TraceId   = New-KlcTraceId }
+  if (-not $AnchorHash){ $AnchorHash = Get-KlcAnchorHash -Seed $Message -Take 12 }
+  $line = "KLC | $TraceId | $DurationMs | $ExitCode | $AnchorHash | $Message"
+  Write-Output $line
+}
+
+function Test-KlcSchema {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][string]$Line)
+  $re = '^[Kk][Ll][Cc]\s\|\s(?<trace>[^|]+)\s\|\s(?<dur>\d+)\s\|\s(?<code>-?\d+)\s\|\s(?<anchor>[0-9a-fA-F]{8,64})\s\|\s(?<msg>.+)$'
+  return [bool]([regex]::IsMatch($Line,$re))
+}
+
+Export-ModuleMember -Function New-KlcTraceId, Get-KlcAnchorHash, Write-KlcLine, Test-KlcSchema

--- a/src/kobong-logger-cli/kobong-logger.psm1
+++ b/src/kobong-logger-cli/kobong-logger.psm1
@@ -3,39 +3,29 @@ Set-StrictMode -Version Latest
 
 function New-KlcTraceId {
   [CmdletBinding()]
-  param([string]$Prefix = "g5")
-  $stamp = (Get-Date).ToString("yyyyMMddHHmmss")
-  $rand  = ([guid]::NewGuid().ToString("N")).Substring(0,6)
-  return "$Prefix-$stamp-$rand"
+  param([string]$Prefix='g5')
+  $stamp = Get-Date -Format 'yyyyMMddHHmmss'
+  $rand  = [guid]::NewGuid().ToString('N').Substring(0,6)
+  "$Prefix-$stamp-$rand"
 }
 
 function Get-KlcAnchorHash {
   [CmdletBinding()]
   param(
-    [string]$Seed,
+    [Parameter(Mandatory)][string]$Seed,
     [int]$Take = 12
   )
   $seed2 = if ($env:GITHUB_SHA) { "$Seed`n$($env:GITHUB_SHA)" } else { $Seed }
   $sha = [System.Security.Cryptography.SHA256]::Create()
   $bytes = [Text.Encoding]::UTF8.GetBytes($seed2)
   $hashBytes = $sha.ComputeHash($bytes)
-  $hex = foreach($b in $hashBytes){ '{0:x2}' -f $b }
+  $hex = foreach ($b in $hashBytes) { '{0:x2}' -f $b }
   $hash = -join $hex
-  return $hash.Substring(0,[Math]::Min($Take,$hash.Length))
-} else { $Seed }
-  $sha = [System.Security.Cryptography.SHA256]::Create()
-  $bytes = [Text.Encoding]::UTF8.GetBytes($seed2)
-  $hash = $sha.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') } -join ''
-  return $hash.Substring(0,[Math]::Min($Take,$hash.Length))
+  $len = [Math]::Min($Take, $hash.Length)
+  $hash.Substring(0, $len)
 }
 
 function Write-KlcLine {
-  <#
-    .SYNOPSIS
-      KLC 1행을 표준 형식으로 출력합니다.
-    .OUTPUTS
-      string: "KLC | traceId | durationMs | exitCode | anchorHash | message"
-  #>
   [CmdletBinding()]
   param(
     [Parameter(Mandatory)][string]$Message,
@@ -44,18 +34,16 @@ function Write-KlcLine {
     [string]$TraceId,
     [string]$AnchorHash
   )
-  if (-not $TraceId)   { $TraceId   = New-KlcTraceId }
-  if (-not $AnchorHash){ $AnchorHash = Get-KlcAnchorHash -Seed $Message -Take 12 }
-  $line = "KLC | $TraceId | $DurationMs | $ExitCode | $AnchorHash | $Message"
-  Write-Output $line
+  if (-not $TraceId)    { $TraceId    = New-KlcTraceId }
+  if (-not $AnchorHash) { $AnchorHash = Get-KlcAnchorHash -Seed $Message -Take 12 }
+  "KLC | $TraceId | $DurationMs | $ExitCode | $AnchorHash | $Message"
 }
 
 function Test-KlcSchema {
   [CmdletBinding()]
   param([Parameter(Mandatory)][string]$Line)
-  $re = '^[Kk][Ll][Cc]\s\|\s(?<trace>[^|]+)\s\|\s(?<dur>\d+)\s\|\s(?<code>-?\d+)\s\|\s(?<anchor>[0-9a-fA-F]{8,64})\s\|\s(?<msg>.+)$'
-  return [bool]([regex]::IsMatch($Line,$re))
+  $re = '^[Kk][Ll][Cc]\s\|\s[^|]+\s\|\s\d+\s\|\s-?\d+\s\|\s[0-9a-fA-F]{8,64}\s\|'
+  [regex]::IsMatch($Line, $re)
 }
 
-Export-ModuleMember -Function New-KlcTraceId, Get-KlcAnchorHash, Write-KlcLine, Test-KlcSchema
-
+Export-ModuleMember -Function New-KlcTraceId,Get-KlcAnchorHash,Write-KlcLine,Test-KlcSchema


### PR DESCRIPTION
## 무엇
- KLC 코어(PSM1) 도입: KLC | traceId | durationMs | exitCode | anchorHash | message
- klc-verify CI 추가(Windows runner)

## 왜
- 계획서 §1/§10 수용 기준: 모든 액션 최소 1행 KLC 로그
- 추적성/롤백 타임라인 확보

## 테스트
- 로컬: scripts/g5/klc-verify.ps1 실행 → [OK] 라인 출력
- CI: klc-verify 잡 녹색

## 영향
- 없음(읽기 전용 도구)
