### PR TITLE
Create ak-apply.yml

### DIFF
--- a/.github/workflows/ak-apply.yml
+++ b/.github/workflows/ak-apply.yml
@@ -1,0 +1,63 @@
+name: AK Apply (manual)
+on:
+  workflow_dispatch:
+    inputs:
+      cmd:  { description: 'rewrite|fix|test', required: true, default: 'fix' }
+      ref:  { description: 'git ref (branch/tag)', required: true, default: 'main' }
+      pr:   { description: 'PR number to comment back (optional)', required: false, default: '' }
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  apply:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: ${{ inputs.ref }}, fetch-depth: 2 }
+
+      - name: Run AK in APPLY mode
+        id: run
+        shell: pwsh
+        env: { CMD: ${{ inputs.cmd }} }
+        run: |
+          Set-StrictMode -Version Latest; $ErrorActionPreference='Stop'
+          $map = @{ rewrite='ak-rewrite.ps1'; fix='ak-fixloop.ps1'; test='ak-test.ps1' }
+          if (-not $map.ContainsKey($env:CMD)) { throw "unknown cmd: $env:CMD" }
+          $pth = @(
+            Join-Path 'scripts/g5' $map[$env:CMD],
+            Join-Path 'scripts'    $map[$env:CMD],
+            $map[$env:CMD]
+          ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $pth) { throw "script not found: $($map[$env:CMD])" }
+
+          ">> APPLY: $pth -ConfirmApply" | Tee-Object .ak-out.txt
+          & pwsh -NoProfile -File $pth -ConfirmApply 2>&1 | Tee-Object -Append .ak-out.txt
+          "exit_code=$LASTEXITCODE" | Out-File $env:GITHUB_OUTPUT -Append
+          if ($LASTEXITCODE -ne 0) { Write-Error "AK APPLY failed with $LASTEXITCODE" }
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ak-apply-logs
+          path: |
+            .ak-out.txt
+            logs/ak7.jsonl
+          if-no-files-found: ignore
+
+      - name: Comment back to PR (optional)
+        if: always() && inputs.pr != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const tail = fs.readFileSync('.ak-out.txt','utf8').split('\n').slice(-80).join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: Number("${{ inputs.pr }}"),
+              body: "🟩 **AK APPLY `${{ inputs.cmd }}`** on `${{ inputs.ref }}`\n\n```\n"+tail+"\n```"
+            });


### PR DESCRIPTION
PR 댓글 워크플로는 그대로 두고, Actions 탭에서만 실행되는 “수동 Apply”를 새로 만듭니다.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
