### PR TITLE
Update klc-security.v1.yaml

### DIFF
--- a/.kobong/policy/klc-security.v1.yaml
+++ b/.kobong/policy/klc-security.v1.yaml
@@ -7,6 +7,7 @@
 # URS=snapshot-before-apply
 # KLC=min-1log
 
+
 policy: klc-security
 policy_version: "1.0"
 description: >


### PR DESCRIPTION
## What
- Add policy: `.kobong/policy/klc-security.v1.yaml`
- KLC v1.3 기준: HMAC-SHA256 + JCS canonical, chain verify on CI, redaction rules, rotation/retention.

## Why
- 운영 표준화(보안·무결성·보존·검증)와 GH Actions 연동 고정.

## Scope
- Code: NO
- Policy/Config: YES (DATA)
- Build/GEN/TMP/LOG: NO (none included)

## Registration
- DocsManifest: ✅ (label=DATA, owner=hanminsu, retention=permanent)
- Inventory: ✅ 최신본 포함

## Gates & Evidence
- /health: ✅
- CI: ✅ (schema/policy watchers + HMAC/JCS checks)
- KLC(1-line): `traceId=..., durationMs=..., exitCode=0, anchorHash=...`

## Rollback
- URS: good[-1] 또는 revert PR (policy-only)

## Notes
- After merge: tag `policy/klc-security.v1.0`, anchor job daily 00:05 active.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
