### PR TITLE
Update ak-dispatch.ps1

### DIFF
--- a/scripts/g5/ak-dispatch.ps1
+++ b/scripts/g5/ak-dispatch.ps1
@@ -32,12 +32,21 @@ function Write-KLC([string]$Level='INFO',[string]$Action='dispatch',[string]$Out
   if($Exit -ne 0){ exit $Exit }
 }
 
-switch ($Command) {
-  'scan'    { & $PSScriptRoot/ak-scan.ps1    -Pr $Pr -Sha $Sha; break }
-  'rewrite' { & $PSScriptRoot/ak-rewrite.ps1 -Pr $Pr -Sha $Sha -ConfirmApply:$ConfirmApply; break }
-  'fixloop' { & $PSScriptRoot/ak-fixloop.ps1 -Pr $Pr -Sha $Sha -ConfirmApply:$ConfirmApply; break }
-  'test'    { & $PSScriptRoot/ak-test.ps1    -Pr $Pr -Sha $Sha; break }
-  default   { Write-KLC 'ERROR' 'dispatch' 'FAILURE' "Unknown: $Command" 13 }
+switch -Regex ($Command.Trim()) {
+  '^help$'          {
+                      # 사용 가능 명령을 콘솔에 친절히 표시
+                      'help|scan|test|rewrite|fixloop|fix'
+                      break
+                    }
+  '^scan$'          { & $PSScriptRoot/ak-scan.ps1    -Pr $Pr -Sha $Sha; break }
+  '^test$'          { & $PSScriptRoot/ak-test.ps1    -Pr $Pr -Sha $Sha; break }
+  '^rewrite$'       { & $PSScriptRoot/ak-rewrite.ps1 -Pr $Pr -Sha $Sha -ConfirmApply:$ConfirmApply; break }
+
+  # fix = fixloop 별칭
+  '^(fix|fixloop)$' { & $PSScriptRoot/ak-fixloop.ps1 -Pr $Pr -Sha $Sha -ConfirmApply:$ConfirmApply; break }
+
+  default           { Write-KLC 'ERROR' 'dispatch' 'FAILURE' ("Unknown: " + $Command) 13 }
 }
-Write-KLC 'INFO' 'dispatch' 'SUCCESS' "done:$Command"
+Write-KLC 'INFO' 'dispatch' 'SUCCESS' ("done:" + $Command)
 exit 0
+


### PR DESCRIPTION
해결 권장안:
① PS 스크립트에 help와 fix(= fixloop 별칭)를 정식 라우팅 추가
② 워크플로 이름을 **ak-dispatch**로 고정(브랜치 보호 체크 이름과 일치)
③ 실행 로그를 콘솔 + 아티팩트 모두 남기도록 워크플로에 업로드 스텝 추가
④ (선택) pr 입력이 있으면 PR 코멘트도 남김

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
