### PR TITLE
Update ak-dispatch.ps1

### DIFF
--- a/scripts/g5/ak-dispatch.ps1
+++ b/scripts/g5/ak-dispatch.ps1
@@ -32,21 +32,17 @@ function Write-KLC([string]$Level='INFO',[string]$Action='dispatch',[string]$Out
   if($Exit -ne 0){ exit $Exit }
 }
 
+# --- 여기부터 교체 ---
 switch -Regex ($Command.Trim()) {
-  '^help$'          {
-                      # 사용 가능 명령을 콘솔에 친절히 표시
-                      'help|scan|test|rewrite|fixloop|fix'
-                      break
-                    }
+  '^help$'          { 'help|scan|test|rewrite|fixloop|fix'; break }
   '^scan$'          { & $PSScriptRoot/ak-scan.ps1    -Pr $Pr -Sha $Sha; break }
   '^test$'          { & $PSScriptRoot/ak-test.ps1    -Pr $Pr -Sha $Sha; break }
   '^rewrite$'       { & $PSScriptRoot/ak-rewrite.ps1 -Pr $Pr -Sha $Sha -ConfirmApply:$ConfirmApply; break }
-
-  # fix = fixloop 별칭
   '^(fix|fixloop)$' { & $PSScriptRoot/ak-fixloop.ps1 -Pr $Pr -Sha $Sha -ConfirmApply:$ConfirmApply; break }
-
   default           { Write-KLC 'ERROR' 'dispatch' 'FAILURE' ("Unknown: " + $Command) 13 }
 }
 Write-KLC 'INFO' 'dispatch' 'SUCCESS' ("done:" + $Command)
 exit 0
+# --- 여기까지 교체 ---
+
 


### PR DESCRIPTION
4) ak-dispatch.ps1 최소 패치(정확 교체 위치)

지금 스크립트는 help/fix가 없어서 혼선이 났었지. 아래 블록만 교체하자.
검색 키워드: switch ( 로 시작해서 exit 0 직전까지.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
