### PR TITLE
Create action.yml

### DIFF
--- a/.github/actions/zip-fetch/action.yml
+++ b/.github/actions/zip-fetch/action.yml
@@ -1,0 +1,44 @@
+name: zip-fetch
+description: Fetch repository via GitHub API zipball (no git.exe)
+inputs:
+  ref:
+    description: commit SHA/branch/tag
+    required: false
+    default: ${{ github.sha }}
+  repo:
+    description: owner/repo (default: current)
+    required: false
+    default: ${{ github.repository }}
+  path:
+    description: destination path
+    required: false
+    default: ${{ github.workspace }}
+runs:
+  using: "composite"
+  steps:
+    - shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        $ErrorActionPreference='Stop'
+        $ref  = '${{ inputs.ref }}'
+        $repo = '${{ inputs.repo }}'
+        $dst  = '${{ inputs.path }}'
+        $owner,$name = $repo.Split('/')
+        $zip  = Join-Path $env:RUNNER_TEMP 'src.zip'
+        $tmp  = Join-Path $env:RUNNER_TEMP 'src'
+        if (Test-Path $tmp) { Remove-Item -Recurse -Force $tmp }
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $Headers = @{
+          Authorization="Bearer $env:GH_TOKEN"
+          "X-GitHub-Api-Version"="2022-11-28"
+          "User-Agent"="zip-fetch"
+          Accept="application/vnd.github+json"
+        }
+        $url = "https://api.github.com/repos/$owner/$name/zipball/$ref"
+        Invoke-WebRequest -Uri $url -Headers $Headers -OutFile $zip
+        Expand-Archive -Path $zip -DestinationPath $tmp -Force
+        $root = Get-ChildItem -Directory $tmp | Select-Object -First 1
+        if (-not $root) { throw "Expand failed: no root dir" }
+        Copy-Item -Path (Join-Path $root.FullName '*') -Destination $dst -Recurse -Force
+        Remove-Item $zip -Force


### PR DESCRIPTION
이제 ZIP 방식을 표준으로 고정해서 다른 워크플로까지 “무경고·무충돌”로 만들자. 재사용 가능한 컴포지트 액션 2개만 추가해두면, 모든 워크플로에서 그대로 불러 쓰면 끝!

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
