### PR TITLE
Update health-smoke.yml

### DIFF
--- a/.github/workflows/health-smoke.yml
+++ b/.github/workflows/health-smoke.yml
@@ -63,19 +63,17 @@ jobs:
       - uses: ./.github/actions/zip-fetch
 
       # 2) 헬스 체크 (입력→시크릿 순 폴백)
+      # -- BEGIN REPLACE: hosted ping with skip when unset --
       - name: Ping GHMON 5182 / 5199 (hosted)
+        if: ${{ (github.event.inputs.base5182 != '' && github.event.inputs.base5199 != '') || (secrets.GHMON_BASE_5182 != '' && secrets.GHMON_BASE_5199 != '') }}
         shell: pwsh
         run: |
           $ErrorActionPreference='Continue'
+          # 우선순위: 입력 > 시크릿
           $in1 = '${{ github.event.inputs.base5182 }}'
           $in2 = '${{ github.event.inputs.base5199 }}'
-          $B1 = if ([string]::IsNullOrWhiteSpace($in1)) { $env:DEF5182 } else { $in1 }
-          $B2 = if ([string]::IsNullOrWhiteSpace($in2)) { $env:DEF5199 } else { $in2 }
-
-          if (-not $B1 -or -not $B2) {
-            Write-Error "base URLs are not set. Provide inputs or set secrets GHMON_BASE_5182 / GHMON_BASE_5199."
-            exit 2
-          }
+          $B1  = if ([string]::IsNullOrWhiteSpace($in1)) { '${{ secrets.GHMON_BASE_5182 }}' } else { $in1 }
+          $B2  = if ([string]::IsNullOrWhiteSpace($in2)) { '${{ secrets.GHMON_BASE_5199 }}' } else { $in2 }
 
           function Test-Health($base){
             try { (Invoke-RestMethod "$base/api/ghmon/health" -TimeoutSec 8).ok } catch { $false }
@@ -88,6 +86,12 @@ jobs:
             Tee-Object -FilePath "logs/health-smoke.log" -Append
 
           if (-not ($ok1 -and $ok2)) { Write-Error "health failed"; exit 1 }
+
+      - name: Skip ping (no base URLs provided)
+        if: ${{ !((github.event.inputs.base5182 != '' && github.event.inputs.base5199 != '') || (secrets.GHMON_BASE_5182 != '' && secrets.GHMON_BASE_5199 != '')) }}
+        run: echo "health-smoke:skipped (no base URLs). Provide inputs or set repo secrets to enable hosted checks."
+      # -- END REPLACE --
+
 
       # 3) 로그 업로드(유일 이름, 409 방지)
       - uses: ./.github/actions/publish-logs


### PR DESCRIPTION
1) 가장 빠른 해결 (지금 바로 실행)

Actions → Health Smoke (daily) → Run workflow 에서

GHMON base: 예) https://ghmon.example.com 또는 http://203.0.113.10:5182

GHMON MOCK base: 예) https://ghmon-mock.example.com 또는 http://203.0.113.10:5199 를 입력하고 실행하세요. (프록시/터널/포트포워딩 등으로 외부에서 열려 있어야 함)

2) 매번 입력하기 싫다면 (시크릿 폴백)

레포 Settings → Secrets and variables → Actions → New repository secret에서:

GHMON_BASE_5182 → 예) https://ghmon.example.com

GHMON_BASE_5199 → 예) https://ghmon-mock.example.com

을 저장하면, Run workflow 입력을 비워도 자동으로 저 값을 씁니다.

3) “입력/시크릿이 없으면 실패 대신 Skip”으로 바꾸기 (부분 수정, 정확 위치)

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
