### PR TITLE
Update weekly-housekeeping.yml

### DIFF
--- a/.github/workflows/weekly-housekeeping.yml
+++ b/.github/workflows/weekly-housekeeping.yml
@@ -3,11 +3,16 @@ name: Weekly Housekeeping
 on:
   schedule:
     - cron: '0 15 * * 0'   # 매주 일요일 00:00 KST (UTC 토 15:00)
-  workflow_dispatch: {}     # 입력 없이 수동 실행
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "실제 삭제 실행(true) / 드라이런(false)"
+        type: boolean
+        default: false
+        required: false
 
 permissions:
-  contents: write           # push할 거면 write 필요
-  actions: read
+  contents: write   # refs 삭제에 필요
 
 concurrency:
   group: weekly-housekeeping
@@ -17,20 +22,49 @@ jobs:
   clean:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # git 사용 전 환경 고정 (128 회피)
-      - name: Git prepare
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-
-      # 실제 정리 스크립트 (경로/옵션 맞게 수정)
-      - name: Housekeeping
+      - name: Dry-run: list old g5/* branches (>=14d)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.apply != true }}
         shell: pwsh
-        run: ./scripts/g5/repo-curate-and-commit.ps1 -Mode housekeeping
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          $ErrorActionPreference='Stop'
+          $days = 14
+          $now = Get-Date
+          $names = gh api repos/$env:REPO/branches --paginate -q '.[].name'
+          foreach ($n in $names) {
+            if ($n -notlike 'g5/*') { continue }
+            $sha  = gh api repos/$env:REPO/branches/$n -q '.commit.sha'
+            $date = gh api repos/$env:REPO/commits/$sha -q '.commit.committer.date'
+            $dt   = [datetime]::Parse($date)
+            $age  = ($now - $dt).TotalDays
+            if ($age -ge $days) {
+              Write-Host "[DRY] $n  ($([math]::Round($age,1)) days)"
+            }
+          }
+
+      - name: Apply: delete old g5/* branches (>=14d)
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.apply == true }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          $ErrorActionPreference='Stop'
+          $days = 14
+          $now = Get-Date
+          $names = gh api repos/$env:REPO/branches --paginate -q '.[].name'
+          foreach ($n in $names) {
+            if ($n -notlike 'g5/*') { continue }
+            $sha  = gh api repos/$env:REPO/branches/$n -q '.commit.sha'
+            $date = gh api repos/$env:REPO/commits/$sha -q '.commit.committer.date'
+            $dt   = [datetime]::Parse($date)
+            $age  = ($now - $dt).TotalDays
+            if ($age -ge $days) {
+              gh api -X DELETE repos/$env:REPO/git/refs/heads/$n
+              Write-Host "deleted $n  ($([math]::Round($age,1)) days)"
+            }
+          }
+
 


### PR DESCRIPTION
목표: exit code 128 방지. zipball도 불필요하게 하고, GitHub API만으로 g5/* 브랜치를 14일 기준으로 정리(또는 dry-run)합니다.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
