### PR TITLE
Update klc-nightly-aggregate.yml

### DIFF
--- a/.github/workflows/klc-nightly-aggregate.yml
+++ b/.github/workflows/klc-nightly-aggregate.yml
@@ -1,45 +1,53 @@
-name: KLC Nightly Aggregate
-
-on:
-  schedule:
-    - cron: '0 15 * * *'   # 매일 00:00 KST (UTC+9) 기준
-  workflow_dispatch:
-
-permissions:
-  contents: read
-
-concurrency:
-  group: klc-nightly-aggregate
-  cancel-in-progress: true
-
-jobs:
-  aggregate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download source (zipball) to workspace
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          SHA:  ${{ github.sha }}
-        run: |
-          $ErrorActionPreference='Stop'
-          $zip = Join-Path $env:RUNNER_TEMP 'src.zip'
-          $tmp = Join-Path $env:RUNNER_TEMP 'src-unzip'
-          Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Force -Path $tmp | Out-Null
-          $headers = @{
-            Authorization = "Bearer $env:GH_TOKEN"
-            "X-GitHub-Api-Version" = "2022-11-28"
-            "User-Agent" = "klc-nightly-aggregate"
-          }
-          $uri = "https://api.github.com/repos/$($env:REPO)/zipball/$($env:SHA)"
-          Invoke-WebRequest -Headers $headers -Uri $uri -OutFile $zip
-          Expand-Archive -Path $zip -DestinationPath $tmp -Force
-          $root = Get-ChildItem -Path $tmp | Where-Object { $_.PSIsContainer } | Select-Object -First 1
-          "SRC=$($root.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Aggregate KLC
-        shell: pwsh
-        working-directory: ${{ env.SRC }}
-        run: ./scripts/g5/klc-aggregate.ps1 -Mode nightly
+--- a/.github/workflows/klc-nightly-aggregate.yml
++++ b/.github/workflows/klc-nightly-aggregate.yml
+@@
+ name: KLC Nightly Aggregate
+-on:
+-  schedule:
+-    - cron: "0 16 * * *"
+-  workflow_dispatch:
++on:
++  schedule:
++    - cron: "0 16 * * *"   # 매일 01:00 KST (예시)
++  workflow_dispatch:
++
++permissions:
++  contents: read
++  actions: read
+ 
+ jobs:
+   aggregate:
+-    runs-on: ubuntu-latest
++    runs-on: ubuntu-latest
++    env:
++      SRC_DIR: ${{ runner.temp }}/src-unzip
+     steps:
+-      - name: Download source
+-        with:
+-          token: ${{ secrets.GITHUB_TOKEN }}
+-          ref: ${{ github.sha }}
++      - name: Download source (zipball) to workspace
++        shell: pwsh
++        env:
++          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++          REPO: ${{ github.repository }}
++          SHA:  ${{ github.sha }}
++        run: |
++          $ErrorActionPreference='Stop'
++          $zip = Join-Path $env:RUNNER_TEMP 'src.zip'
++          $tmp = "${{ env.SRC_DIR }}"
++          Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
++          New-Item -ItemType Directory -Force -Path $tmp | Out-Null
++          $Headers = @{ Authorization = "Bearer $env:GH_TOKEN"; "X-GitHub-Api-Version" = "2022-11-28" }
++          $Uri = "https://api.github.com/repos/$env:REPO/zipball/$env:SHA"
++          Invoke-WebRequest -Headers $Headers -Uri $Uri -OutFile $zip
++          Expand-Archive -Path $zip -DestinationPath $tmp -Force
++          # 압축 내부는 1개 루트 폴더. 그 안을 SRC_DIR 최상위로 승격
++          $inner = Get-ChildItem $tmp | ? { $_.PSIsContainer } | Select-Object -First 1
++          if ($inner) { Get-ChildItem $inner.FullName -Force | Move-Item -Destination $tmp -Force }
++          Remove-Item $inner.FullName -Recurse -Force -ErrorAction SilentlyContinue
++
++      - name: Aggregate KLC
++        shell: pwsh
++        working-directory: ${{ env.SRC_DIR }}
++        run: ./scripts/g5/klc-aggregate.ps1 -Mode nightly -Root "${{ env.SRC_DIR }}"


### PR DESCRIPTION
.github/workflows/klc-nightly-aggregate.yml 에러

Required property is missing: uses 는 한 스텝이 uses: 없이 with:만 있거나 들여쓰기 깨진 경우에 납니다. 동시에 git 체크아웃 없이 zip-fetch 경로로 전개합니다. (exit code 128 회피)

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
