### PR TITLE
Create settings.psd1

### DIFF
--- a/settings.psd1
+++ b/settings.psd1
@@ -1,0 +1,15 @@
+@{
+  # 특정 규칙 제외(팀 합의로 단계적 정리)
+  ExcludeRules = @(
+    'PSAvoidUsingWrite-Host'          # 로컬 도구성 스크립트에서는 허용
+  )
+
+  # 규칙별 심각도/옵션 재정의
+  Rules = @{
+    PSAvoidUsingInvokeExpression       = @{ Severity = 'Error' }   # 동적 실행 금지
+    PSAvoidUsingPlainTextForPassword   = @{ Severity = 'Error' }   # 평문 비밀번호 금지
+    PSUseSupportsShouldProcess         = @{ Severity = 'Error' }   # 파괴적 명령엔 -WhatIf
+    PSUseApprovedVerbs                 = @{ Severity = 'Warning' } # 경고로만
+    PSUseBOMForUnicodeEncodedFile      = @{ Severity = 'Warning' } # 팀 선호에 맞게 조정
+  }
+}


### PR DESCRIPTION
기본값은 Soft Gate: 변경된 파일만 검사, Error 있으면 실패.

수동 실행에서 warn_threshold를 예: 10 으로 주면 경고 10개 초과 시 실패(Soft/Hard 모두 적용).

PR에 라벨 psa-skip 달면 해당 PR은 면제됩니다(잡 자체가 스킵).

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
