### PR TITLE
Create psanalyze.yml

### DIFF
--- a/.github/workflows/psanalyze.yml
+++ b/.github/workflows/psanalyze.yml
@@ -1,0 +1,160 @@
+name: PSScriptAnalyzer
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: monitor | soft | hard
+        required: false
+        default: soft
+        type: choice
+        options: [monitor, soft, hard]
+      warn_threshold:
+        description: "Fail if warnings > N (empty = ignore). Example: 10"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  psanalyze:
+    # 라벨 기반 면제: PR에 'psa-skip' 라벨이 있으면 전체 잡을 건너뜀
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'psa-skip') }}
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Decide mode & thresholds
+        id: cfg
+        shell: pwsh
+        run: |
+          $mode = '${{ github.event.inputs.mode }}'
+          if ([string]::IsNullOrWhiteSpace($mode)) { $mode = 'soft' }
+          $wtxt = '${{ github.event.inputs.warn_threshold }}'
+          if (-not $wtxt -or ($wtxt -notmatch '^\d+$')) { $wtxt = '' }
+          "mode=$mode"           | Out-File $env:GITHUB_OUTPUT -Append
+          "warn_threshold=$wtxt" | Out-File $env:GITHUB_OUTPUT -Append
+
+      - name: Collect target files
+        id: files
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory "$env:GITHUB_WORKSPACE"
+          $all = Get-ChildItem -Recurse -File -Include *.ps1,*.psm1,*.psd1 | ForEach-Object FullName
+          $changed = @()
+          if ('${{ github.event_name }}' -eq 'pull_request') {
+            $base='${{ github.event.pull_request.base.sha }}'
+            $head='${{ github.event.pull_request.head.sha }}'
+            $changed = (git diff --name-only $base $head) | Where-Object { $_ -match '\.(ps1|psm1|psd1)$' } | ForEach-Object { Resolve-Path $_ }
+          }
+          $mode='${{ steps.cfg.outputs.mode }}'
+          if ($mode -eq 'soft' -and $changed.Count -gt 0) { $targets = $changed } else { $targets = $all }
+          if (-not $targets) {
+            "targets=" | Out-File $env:GITHUB_OUTPUT -Append
+            "# PSScriptAnalyzer Summary`n- Mode: $mode`n- Targets: 0 (skipped)`n- Reason: no PowerShell files" | Out-File $env:GITHUB_STEP_SUMMARY -Append
+            exit 0
+          }
+          $targets -join "`n" | Set-Content targets.txt
+          "targets=$(Get-Content targets.txt -Raw)" | Out-File $env:GITHUB_OUTPUT -Append
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+
+      - name: Run analyzer
+        id: scan
+        if: steps.files.outputs.targets != ''
+        shell: pwsh
+        run: |
+          $targets = Get-Content targets.txt
+          $settings = ''
+          if (Test-Path './settings.psd1') { $settings = (Resolve-Path './settings.psd1').Path }
+          $params = @{
+            Path     = $targets
+            Recurse  = $true
+            Severity = @('Error','Warning')
+            Verbose  = $false
+          }
+          if ($settings) { $params['Settings'] = $settings }
+
+          $results = Invoke-ScriptAnalyzer @params
+
+          $err  = ($results | Where-Object Severity -eq 'Error').Count
+          $warn = ($results | Where-Object Severity -eq 'Warning').Count
+          "errors=$err" | Out-File $env:GITHUB_OUTPUT -Append
+          "warnings=$warn" | Out-File $env:GITHUB_OUTPUT -Append
+          "used_settings=$settings" | Out-File $env:GITHUB_OUTPUT -Append
+
+          # SARIF(minimal) 생성
+          $sarif = @{
+            version = "2.1.0"
+            runs = @(@{
+              tool = @{ driver = @{ name = "PSScriptAnalyzer" } }
+              results = @(
+                $results | ForEach-Object {
+                  @{
+                    ruleId  = $_.RuleName
+                    level   = (($_.Severity -eq 'Error') ? 'error' : 'warning')
+                    message = @{ text = $_.Message }
+                    locations = @(@{
+                      physicalLocation = @{
+                        artifactLocation = @{ uri = $_.ScriptPath }
+                        region = @{ startLine = $_.Line }
+                      }
+                    })
+                  }
+                }
+              )
+            })
+          } | ConvertTo-Json -Depth 6
+          $sarif | Out-File results.sarif -Encoding utf8
+
+      - name: Upload SARIF
+        if: steps.files.outputs.targets != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Gate (errors + warning threshold)
+        if: steps.files.outputs.targets != ''
+        shell: pwsh
+        run: |
+          $mode   = '${{ steps.cfg.outputs.mode }}'
+          $err    = [int]'${{ steps.scan.outputs.errors }}'
+          $warn   = [int]'${{ steps.scan.outputs.warnings }}'
+          $wth    = '${{ steps.cfg.outputs.warn_threshold }}'
+          $useSet = '${{ steps.scan.outputs.used_settings }}'
+          $fail   = $false
+          $reasons = @()
+
+          switch ($mode) {
+            'monitor' { }
+            'soft'    { if ($err -gt 0) { $fail = $true; $reasons += "$err error(s)" } }
+            'hard'    { if ($err -gt 0) { $fail = $true; $reasons += "$err error(s)" } }
+          }
+
+          if ($wth -and ($warn -gt [int]$wth)) {
+            $fail = $true
+            $reasons += "warnings $warn > threshold $wth"
+          }
+
+          $targetCount = (Get-Content targets.txt).Count
+          $summary = @()
+          $summary += "### PSScriptAnalyzer Summary"
+          $summary += "- Mode: $mode"
+          $summary += "- Targets: $targetCount"
+          if ($useSet) { $summary += "- Settings: $useSet" } else { $summary += "- Settings: (default)" }
+          $summary += "- Errors: $err"
+          $summary += "- Warnings: $warn"
+          if ($wth)   { $summary += "- Warn threshold: $wth" }
+          $summary += "- Gate: " + ($(if ($fail) { "❌ FAIL ($($reasons -join '; '))" } else { "✅ PASS" }))
+          $summary -join "`n" | Out-File $env:GITHUB_STEP_SUMMARY -Append
+
+          if ($fail) { throw "PSScriptAnalyzer gate failed: $($reasons -join '; ')." }


### PR DESCRIPTION
좋아. settings.psd1 적용 + 라벨 면제 + 경고 임계치까지 반영한 “맞춤형 PSScriptAnalyzer 워크플로”를 바로 쓸 수 있게 드릴게요. 아래 YAML을 .github/workflows/psanalyze.yml로 저장하고, 두 번째 블록의 settings.psd1는 원한다면 레포 루트에 추가하세요.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
