### PR TITLE
Update psanalyze.yml

### DIFF
--- a/.github/workflows/psanalyze.yml
+++ b/.github/workflows/psanalyze.yml
@@ -36,17 +36,24 @@ jobs:
         id: cfg
         shell: pwsh
         run: |
-          $isPR = '${{ github.event_name }}' -eq 'pull_request'
-          $isMain = '${{ github.ref }}' -eq 'refs/heads/main'
-          if ($isPR) {
-          $mode = 'soft'; $wtxt = ''         # PR은 경고로 막지 않음
-          } elseif ($isMain) {
-          $mode = 'hard'; $wtxt = '10'       # main은 엄격
-          } else {
-          $mode = 'soft'; $wtxt = ''         # 기타는 완화
-          }
-          "mode=$mode"           | Out-File $env:GITHUB_OUTPUT -Append
-          "warn_threshold=$wtxt" | Out-File $env:GITHUB_OUTPUT -Append
+         $isPR     = '${{ github.event_name }}' -eq 'pull_request'
+         $isManual = '${{ github.event_name }}' -eq 'workflow_dispatch'
+         $isMain   = '${{ github.ref }}' -eq 'refs/heads/main'
+
+         if ($isPR -or $isManual) {
+         $mode = 'soft'    # PR/수동은 경고로 막지 않음
+         $wtxt = ''        # 경고 임계값 비활성
+         } elseif ($isMain) {
+         $mode = 'hard'    # main은 엄격 (에러만 차단)
+         $wtxt = ''        # 경고 임계값 비활성(원하면 숫자 지정)
+         } else {
+         $mode = 'soft'
+         $wtxt = ''
+         }
+
+         "mode=$mode"           | Out-File $env:GITHUB_OUTPUT -Append
+         "warn_threshold=$wtxt" | Out-File $env:GITHUB_OUTPUT -Append
+
 
 
       - name: Collect target files


### PR DESCRIPTION
PR은 완화, main은 엄격 — 영구 패치 (선택 2)
psanalyze.yml의 “Decide mode & thresholds” 스텝을 아래로 교체하면, PR/수동 실행: soft(경고 미차단)
main push: hard(에러만 차단, 경고 임계값 기본 비활성)
이 됩니다.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
