### PR TITLE
Update ak-commands.yml

### DIFF
--- a/.github/workflows/ak-commands.yml
+++ b/.github/workflows/ak-commands.yml
@@ -7,105 +7,103 @@
 # -------------------------------------------
 
 name: AK Commands (ChatOps)
+
 on:
   workflow_dispatch:
     inputs:
       cmd:
-        description: '실행할 커맨드 (bash 기반)'
+        description: '실행할 커맨드 (bash | pwsh | gh | 기타)'
         required: true
+        type: string
       args:
-        description: '인수 (공백으로 구분)'
+        description: '인수(쉘에서 치는 그대로)'
         required: false
-        default: ''
+        type: string
 
 permissions:
   contents: read
 
 jobs:
-  no-tracked-logs:
-    name: Guard logs/ (no tracked logs)
+  guard-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+      - name: Ensure no tracked files under logs/ (except .gitkeep)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t tracked < <(git ls-files 'logs/*' | grep -v '^logs/.gitkeep$' || true)
+          if (( ${#tracked[@]} )); then
+            printf '::error::Tracked files under logs/: %s\n' "${tracked[@]}"
+            exit 1
+          fi
+
+  run-command:
+    needs: guard-logs
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      statuses: write
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: false
 
-      - name: Scan tracked files under logs/
-        id: scan
-        shell: bash
-        run: |
-          set -euo pipefail
-          files="$(git ls-files -- 'logs/*' ':!logs/.gitkeep' || true)"
-          if [ -n "$files" ]; then
-            echo "has_tracked=true" >> "$GITHUB_OUTPUT"
-            echo "$files" > tracked.txt
-          else
-            echo "has_tracked=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Mark status (fail)
-        if: steps.scan.outputs.has_tracked == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const files = fs.readFileSync('tracked.txt', 'utf8').trim().split('\n');
-            const preview = files.length ? files[0] + (files.length > 1 ? ' …' : '') : '';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: 'failure',
-              context: 'guard-logs-ignored/no-tracked-logs',
-              description: preview || 'Tracked files under logs/'
-            });
-            core.setFailed(`❌ Tracked log files detected: ${preview}`);
-
-      - name: Mark status (success)
-        if: steps.scan.outputs.has_tracked == 'false'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: 'success',
-              context: 'guard-logs-ignored/no-tracked-logs',
-              description: 'No tracked files under logs/'
-            });
-
-  run-command:
-    name: Run Command
-    runs-on: ubuntu-latest
-    needs: [ no-tracked-logs ]
-    if: needs.no-tracked-logs.result == 'success'
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: 입력 확인
         shell: bash
         run: |
-          echo "입력 커맨드: ${{ github.event.inputs.cmd }}"
-          echo "입력 인수:   ${{ github.event.inputs.args }}"
+          echo "입력 커맨드 : ${{ inputs.cmd }}"
+          echo "입력 인수   : ${{ inputs.args }}"
 
-      - name: 명령 실행
+      - name: Run Command
         shell: bash
         env:
-          CMD: ${{ github.event.inputs.cmd }}
-          ARGS: ${{ github.event.inputs.args }}
+          # ❗️절대 'cmd=' 같은 접두어 넣지 않음
+          CMD: ${{ inputs.cmd }}
+          ARGS: ${{ inputs.args }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          echo "▶ ${CMD} ${ARGS}"
-          ${CMD} ${ARGS}
+
+          if [[ -z "${CMD}" ]]; then
+            echo "::error::CMD is empty"; exit 1
+          fi
+
+          case "${CMD}" in
+            pwsh|powershell|pwsh.exe)
+              if [[ -z "${ARGS}" ]]; then
+                echo "::error::pwsh에는 ARGS가 필요합니다 (예: -NoProfile -Command \"...\" 또는 -File path.ps1)"; exit 1
+              fi
+              pwsh -NoProfile ${ARGS}
+              ;;
+
+            bash|sh|/bin/bash)
+              if [[ -z "${ARGS}" ]]; then
+                echo "::error::bash에는 ARGS가 필요합니다 (예: -lc 'echo ok')"; exit 1
+              fi
+              # 사용자가 -lc를 안 넣어도 최소 실행되게 보정
+              if [[ "${ARGS}" =~ ^-l?c[[:space:]] ]]; then
+                bash ${ARGS}
+              else
+                bash -lc "${ARGS}"
+              fi
+              ;;
+
+            gh)
+              export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+              if [[ -z "${GH_TOKEN}" ]]; then
+                echo "::error::GH_TOKEN not set"; exit 4
+              fi
+              gh ${ARGS}
+              ;;
+
+            *)
+              # 일반 커맨드
+              ${CMD} ${ARGS}
+              ;;
+          esac
+
           echo "✅ 명령 실행 완료"


### PR DESCRIPTION
env:에 CMD: cmd="${{ inputs.cmd }}"처럼 cmd= 접두어가 들어간 값을 넣고 있습니다.

bash/pwsh/gh 실행 분기와 인용(따옴표)도 안전하지 않아 EOF / 127 / 4 등 오류가 재현됩니다.

아래 전체 교체본으로 쓰면 바로 잡힙니다.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
