### PR TITLE
Update ak-commands.yml

### DIFF
--- a/.github/workflows/ak-commands.yml
+++ b/.github/workflows/ak-commands.yml
@@ -1,109 +1,181 @@
-# ===========================================
-# AK-COMMANDS (fixed) : Kobong-Orchestrator ChatOps
-# - PR 코멘트의 '/ak <cmd>' 또는 수동 inputs 로 실행
-# - scripts/g5/ak-dispatch.ps1 를 호출하여 help/test/scan/fixloop 수행
-# - logs/ak7.jsonl 아티팩트 업로드
-# - 동시실행 격리: 레포+PR+cmd 기준
-# ===========================================
+# =========================================================
+# AK-COMMANDS : ChatOps 실행기
+# - PR 코멘트의 "/ak <command> [args]" 또는 수동 입력으로 트리거
+# - PR 코드는 체크아웃하되, 실행 스크립트(scripts/g5/*)는 항상 main에서 강제 덮어써서 보안 강화
+# - GPT-5(OpenAI API)로 PR 분석/플랜 코멘트(선택 기능, 키 없으면 자동 skip)
+# - 지원 명령: help | test | scan | rewrite | fixloop (필요 시 추가 가능)
+# =========================================================
+
 name: ak-commands
 
-"on":
+on:
   issue_comment:
     types: [created]
   workflow_dispatch:
     inputs:
       pr:
-        description: "Pull request number"
+        description: 'Pull Request number'
         required: true
       command:
-        description: "ak subcommand (help|test|scan|fixloop)"
+        description: 'ak command (help|test|scan|rewrite|fixloop)'
         required: true
-      rawargs:
-        description: "Optional raw args for the command"
+      args:
+        description: 'additional args'
         required: false
-        default: ""
+        default: ''
 
 permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+  contents: read          # 코드 읽기
+  pull-requests: write    # 코멘트/체크
+  issues: write           # 이슈/PR 코멘트
   checks: write
 
-concurrency:
-  group: ak-${{ github.repository }}-${{ github.event_name == 'workflow_dispatch' && inputs.pr || github.event.issue.number }}-${{ github.event_name == 'workflow_dispatch' && inputs.command || 'cmd' }}
-  cancel-in-progress: false
-
 jobs:
-  run-ak:
-    runs-on: ubuntu-24.04
+  run:
+    runs-on: ubuntu-latest
+
     steps:
-      - name: Resolve inputs
+      - name: Resolve inputs from comment or dispatch
         id: resolve
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "pr=${{ inputs.pr }}" >> "$GITHUB_OUTPUT"
-            echo "cmd=${{ inputs.command }}" >> "$GITHUB_OUTPUT"
-            echo "raw=${{ inputs.rawargs }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          body=$(printf "%s" "${{ github.event.comment.body }}")
-          cmd=$(printf "%s" "$body" | sed -n 's!.*/ak[[:space:]]\+\([a-z0-9-]\+\).*!\1!p')
-          echo "pr=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-          echo "cmd=$cmd" >> "$GITHUB_OUTPUT"
-          echo "raw=" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout PR head
-        uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ steps.resolve.outputs.pr }}/head
-          fetch-depth: 1
-
-      - name: Bootstrap ak logs
-        shell: bash
-        run: |
-          mkdir -p logs
-          printf '{"timestamp":"%s","level":"INFO","action":"bootstrap","message":"init"}\n' "$(date -Iseconds)" >> logs/ak7.jsonl
-
-      - name: Hydrate scripts from main if missing
-        shell: bash
-        run: |
-          if [ ! -d scripts/g5 ] || [ ! -f scripts/g5/ak-dispatch.ps1 ]; then
-            echo "::notice::scripts/g5 missing; hydrating from origin/main"
-            git fetch --depth=1 origin main
-            git checkout origin/main -- scripts/g5/
-          fi
-          ls -la scripts/g5
-
-      - name: Dispatch
-        shell: pwsh
-        run: |
-          $ErrorActionPreference='Continue'
-          $cmd    = '${{ steps.resolve.outputs.cmd }}'
-          $pr     = '${{ steps.resolve.outputs.pr }}'
-          $raw    = '${{ steps.resolve.outputs.raw }}'
-          ./scripts/g5/ak-dispatch.ps1 -Command $cmd -Pr $pr -RawArgs $raw
-
-      - name: Upload ak logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ak7-logs
-          path: logs/ak7.jsonl
-          if-no-files-found: warn
-          retention-days: 7
-
-      - name: Post start/result
-        if: ${{ github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = '${{ steps.resolve.outputs.pr }}';
-            const cmd = '${{ steps.resolve.outputs.cmd }}';
-            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `✅ /ak **${cmd}** started for PR #${pr}\n\nRun: ${url}`;
-            if (context.eventName === 'issue_comment') {
-              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: Number(pr), body });
-            } else {
-              core.summary.addHeading('/ak').addRaw(body).write();
+            const core = require('@actions/core');
+            const ev = context.eventName;
+
+            let pr = core.getInput('pr');
+            let cmd = core.getInput('command');
+            let args = core.getInput('args') || '';
+
+            if (ev === 'issue_comment') {
+              // PR 코멘트만 허용
+              if (!context.payload.issue.pull_request) {
+                core.notice('This is not a PR comment. Skipping.');
+                core.setOutput('skip', 'true');
+                return;
+              }
+              pr = String(context.payload.issue.number);
+
+              const body = context.payload.comment.body.trim();
+              const m = body.match(/^\/ak\s+([a-zA-Z0-9:_-]+)(?:\s+(.+))?$/);
+              if (!m) { core.setOutput('skip', 'true'); return; }
+              cmd = m[1].toLowerCase();
+              args = (m[2] || '').trim();
             }
+
+            const allowed = new Set(['help','test','scan','rewrite','fixloop']);
+            if (!allowed.has(cmd)) {
+              core.setFailed(`Unknown command: ${cmd}`);
+              return;
+            }
+
+            // PR 헤드 repo/ref 정보 가져오기
+            const {data: prObj} = await github.rest.pulls.get({ ...context.repo, pull_number: Number(pr) });
+            const headRepo = prObj.head.repo.full_name;
+            const headRef  = prObj.head.ref;
+
+            core.setOutput('skip', 'false');
+            core.setOutput('pr', pr);
+            core.setOutput('cmd', cmd);
+            core.setOutput('args', args);
+            core.setOutput('headRepo', headRepo);
+            core.setOutput('headRef', headRef);
+
+      - name: Stop if not an /ak command
+        if: ${{ steps.resolve.outputs.skip == 'true' }}
+        run: echo "No /ak command. Done."
+
+      - name: Checkout PR HEAD (code only)
+        if: ${{ steps.resolve.outputs.skip != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.resolve.outputs.headRepo }}
+          ref: ${{ steps.resolve.outputs.headRef }}
+          fetch-depth: 0
+
+      - name: Hydrate protected scripts from main (force)
+        if: ${{ steps.resolve.outputs.skip != 'true' }}
+        run: |
+          git fetch origin +refs/heads/main:refs/remotes/origin/main
+          # scripts/g5/* 는 항상 main 기준으로 덮어쓰기(보안)
+          if git ls-tree -r --name-only origin/main | grep -q '^scripts/g5/'; then
+            git checkout origin/main -- scripts/g5/
+          fi
+
+      - name: Print context
+        if: ${{ steps.resolve.outputs.skip != 'true' }}
+        run: |
+          echo "PR: ${{ steps.resolve.outputs.pr }}"
+          echo "CMD: ${{ steps.resolve.outputs.cmd }}"
+          echo "ARGS: ${{ steps.resolve.outputs.args }}"
+
+      - name: (Optional) GPT-5: Analyze PR & propose plan
+        if: ${{ steps.resolve.outputs.skip != 'true' }}
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY not set; skipping GPT analysis."
+            exit 0
+          fi
+          DIFF=$(gh api repos/${{ github.repository }}/pulls/${{ steps.resolve.outputs.pr }} --jq '.title + "\n\n" + .body' ; \
+                 echo -e "\n--- DIFF ---\n" ; \
+                 gh api repos/${{ github.repository }}/pulls/${{ steps.resolve.outputs.pr }}/files --paginate --jq '.[] | "### " + .filename + "\n" + .patch' | head -c 90000)
+          JSON=$(jq -n --arg content "$DIFF" --arg cmd "${{ steps.resolve.outputs.cmd }}" '
+            {
+              model: "gpt-5",
+              messages: [
+                {role:"system", content:"You are a senior CI reviewer. Output concise, actionable steps."},
+                {role:"user", content: ("Command: " + $cmd + "\n\n" + $content)}
+              ],
+              temperature: 0.2
+            }')
+          URL="${OPENAI_BASE_URL:-https://api.openai.com/v1}/chat/completions"
+          RESP=$(curl -sS -H "Authorization: Bearer ${OPENAI_API_KEY}" -H "Content-Type: application/json" -d "$JSON" "$URL")
+          PLAN=$(echo "$RESP" | jq -r '.choices[0].message.content // "No response"')
+          printf "%s\n" "$PLAN" > gpt5-plan.txt
+          echo "GPT-5 plan saved."
+
+      - name: Run dispatcher (pwsh)
+        if: ${{ steps.resolve.outputs.skip != 'true' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $cmd  = "${{ steps.resolve.outputs.cmd }}"
+          $args = "${{ steps.resolve.outputs.args }}"
+          if (Test-Path "scripts/g5/ak-dispatch.ps1") {
+            ./scripts/g5/ak-dispatch.ps1 -Command $cmd -Pr "${{ steps.resolve.outputs.pr }}" -Args $args
+          } else {
+            Write-Host "scripts/g5/ak-dispatch.ps1 not found."; exit 1
+          }
+
+      - name: Upload artifacts (logs + plan)
+        if: ${{ steps.resolve.outputs.skip != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ak-commands-${{ steps.resolve.outputs.pr }}-${{ steps.resolve.outputs.cmd }}
+          path: |
+            logs/**
+            gpt5-plan.txt
+          if-no-files-found: ignore
+
+      - name: Comment back
+        if: ${{ steps.resolve.outputs.skip != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const pr = Number('${{ steps.resolve.outputs.pr }}');
+            const cmd = '${{ steps.resolve.outputs.cmd }}';
+            const run = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            let body = `✅ /ak **${cmd}** started for PR #${pr}\n\nRun: ${run}`;
+            // gpt5-plan.txt 있으면 함께 첨부
+            try {
+              const fs = require('fs');
+              if (fs.existsSync('gpt5-plan.txt')) {
+                const plan = fs.readFileSync('gpt5-plan.txt','utf8');
+                body += `\n\n**GPT-5 Plan**\n\n${plan}`;
+              }
+            } catch {}
+            await github.rest.issues.createComment({owner, repo, issue_number: pr, body});


### PR DESCRIPTION
# ========================================================= # AK-COMMANDS : ChatOps 실행기
# - PR 코멘트의 "/ak <command> [args]" 또는 수동 입력으로 트리거
# - PR 코드는 체크아웃하되, 실행 스크립트(scripts/g5/*)는 항상 main에서 강제 덮어써서 보안 강화 # - GPT-5(OpenAI API)로 PR 분석/플랜 코멘트(선택 기능, 키 없으면 자동 skip) # - 지원 명령: help | test | scan | rewrite | fixloop (필요 시 추가 가능) # =========================================================

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
