### PR TITLE
Update ak-auto.yml

### DIFF
--- a/.github/workflows/ak-auto.yml
+++ b/.github/workflows/ak-auto.yml
@@ -48,6 +48,79 @@ jobs:
             core.setOutput('num', prNum.toString());
             core.setOutput('sha', pr.head.sha);
 
+--- a/.github/workflows/ak-auto.yml
++++ b/.github/workflows/ak-auto.yml
+@@
+-      - name: /ak test
++      - name: /ak test
++        id: step_test
+         if: ${{ steps.gate.outputs.skip != 'true' }}
+         shell: pwsh
+         run: ./scripts/g5/ak-dispatch.ps1 -Command test -Pr '${{ steps.pr.outputs.num }}'
++
++      - name: Label stage test-ok
++        if: ${{ steps.gate.outputs.skip != 'true' && steps.step_test.outcome == 'success' }}
++        uses: actions/github-script@v7
++        with:
++          script: |
++            const pr = Number('${{ steps.pr.outputs.num }}');
++            const {owner, repo} = context.repo;
++            const label = 'ak:stage:test-ok';
++            try {
++              await github.rest.issues.addLabels({owner, repo, issue_number: pr, labels: [label]});
++            } catch (e) {
++              try { await github.rest.issues.createLabel({owner, repo, name: label, color: '0e8a16'}); } catch (_) {}
++              await github.rest.issues.addLabels({owner, repo, issue_number: pr, labels: [label]});
++            }
+@@
+-      - name: /ak scan --all
++      - name: /ak scan --all
++        id: step_scan
+         if: ${{ steps.gate.outputs.skip != 'true' }}
+         shell: pwsh
+         run: ./scripts/g5/ak-dispatch.ps1 -Command scan -RawArgs '--all' -Pr '${{ steps.pr.outputs.num }}'
++
++      - name: Label stage scan-ok
++        if: ${{ steps.gate.outputs.skip != 'true' && steps.step_scan.outcome == 'success' }}
++        uses: actions/github-script@v7
++        with:
++          script: |
++            const pr = Number('${{ steps.pr.outputs.num }}');
++            const {owner, repo} = context.repo;
++            const label = 'ak:stage:scan-ok';
++            try {
++              await github.rest.issues.addLabels({owner, repo, issue_number: pr, labels: [label]});
++            } catch (e) {
++              try { await github.rest.issues.createLabel({owner, repo, name: label, color: '1f77b4'}); } catch (_) {}
++              await github.rest.issues.addLabels({owner, repo, issue_number: pr, labels: [label]});
++            }
+@@
+-      - name: /ak fixloop preview
++      - name: /ak fixloop preview
++        id: step_preview
+         if: ${{ steps.gate.outputs.skip != 'true' }}
+         shell: pwsh
+         run: |
+           $ErrorActionPreference='Continue'
+           ./scripts/g5/ak-dispatch.ps1 -Command fixloop -RawArgs 'preview' -Pr '${{ steps.pr.outputs.num }}' ; exit 0
++
++      - name: Label stage preview-ok
++        if: ${{ steps.gate.outputs.skip != 'true' && steps.step_preview.outcome == 'success' }}
++        uses: actions/github-script@v7
++        with:
++          script: |
++            const pr = Number('${{ steps.pr.outputs.num }}');
++            const {owner, repo} = context.repo;
++            const label = 'ak:stage:preview-ok';
++            try {
++              await github.rest.issues.addLabels({owner, repo, issue_number: pr, labels: [label]});
++            } catch (e) {
++              try { await github.rest.issues.createLabel({owner, repo, name: label, color: 'fbca04'}); } catch (_) {}
++              await github.rest.issues.addLabels({owner, repo, issue_number: pr, labels: [label]});
++            }
+
+            
+
       - name: Check required label ak:auto
         id: gate
         uses: actions/github-script@v7


### PR DESCRIPTION
ak-auto.yml에 단계 성공 시 상태 라벨을 자동 부여하도록, 최소 변경만 넣었어.
(각 단계 스텝에 id 부여 → 직후 라벨 추가 스텝. 라벨이 없으면 자동 생성 후 부여)

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
