### PR TITLE
Update psanalyze.yml

### DIFF
--- a/.github/workflows/psanalyze.yml
+++ b/.github/workflows/psanalyze.yml
@@ -1,236 +1,111 @@
-name: PSScriptAnalyzer
+# =========================================================
+# 파일 용도 : PowerShell 스크립트 정적 점검(PSScriptAnalyzer) 전용 워크플로
+# 동작 방식 : PR 또는 수동 실행 시 scripts/g5 하위의 .ps1/.psm1 등을 검사
+# 연관 파일 : scripts/g5/*  .github/workflows/ak-selftest.yml (보완용)
+# 안전 가드 : PSResourceGet 우선 설치 → 미존재 시 PowerShellGet(v2) 폴백
+#             Windows/Ubuntu 공통 동작, 설치 실패시 즉시 실패
+# 산출물    : 콘솔 요약, artifacts/pssa-findings.txt (있을 경우)
+# =========================================================
+name: psanalyze
 
 on:
   pull_request:
-  workflow_dispatch:
-    inputs:
-      mode:
-        description: monitor | soft | hard
-        required: false
-        default: soft
-        type: choice
-        options: [monitor, soft, hard]
-      warn_threshold:
-        description: "Fail if warnings > N (empty = ignore)"
-        required: false
-        type: string
+    paths:
+      - "scripts/g5/**"
+  workflow_dispatch: {}
 
 permissions:
   contents: read
-  security-events: write
+
+concurrency:
+  group: psanalyze-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   psanalyze:
-    # 라벨로 완전 스킵 가능
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'psa-skip') }}
-    runs-on: windows-latest
-
+    name: psanalyze
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout (full history for PR base)
+      - name: Checkout full history for PR base
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: false
 
-      - name: Decide mode & thresholds
-        id: cfg
+      - name: Print PowerShell environment
         shell: pwsh
         run: |
-         $isPR     = '${{ github.event_name }}' -eq 'pull_request'
-         $isManual = '${{ github.event_name }}' -eq 'workflow_dispatch'
-         $isMain   = '${{ github.ref }}' -eq 'refs/heads/main'
+          $v = $PSVersionTable.PSVersion.ToString()
+          $hasPSR = [bool](Get-Command Install-PSResource -ErrorAction SilentlyContinue)
+          $pget = Get-Module PowerShellGet -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+          Write-Host "pwsh=$v  Install-PSResource?=$hasPSR  PowerShellGet=$($pget.Version)"
 
-         if ($isPR -or $isManual) {
-         $mode = 'soft'    # PR/수동은 경고로 막지 않음
-         $wtxt = ''        # 경고 임계값 비활성
-         } elseif ($isMain) {
-         $mode = 'hard'    # main은 엄격 (에러만 차단)
-         $wtxt = ''        # 경고 임계값 비활성(원하면 숫자 지정)
-         } else {
-         $mode = 'soft'
-         $wtxt = ''
-         }
-
-         "mode=$mode"           | Out-File $env:GITHUB_OUTPUT -Append
-         "warn_threshold=$wtxt" | Out-File $env:GITHUB_OUTPUT -Append
-
-
-
-      - name: Collect target files
-        id: files
+      - name: Install PSScriptAnalyzer robust
         shell: pwsh
         run: |
-          git config --global --add safe.directory "$env:GITHUB_WORKSPACE"
+          $ErrorActionPreference = 'Stop'
 
-          $all = Get-ChildItem -Recurse -File -Include *.ps1,*.psm1,*.psd1 |
-                 Where-Object {
-                   $_.FullName -notmatch '\\\.git(\\|$)' -and
-                   $_.FullName -notmatch '\\\.githooks(\\|$)' -and
-                   $_.Name -notmatch '복사본' -and                    # 👈 한글 '복사본' 제외
-                   $_.Name -notmatch '(?i)\bcopy\b' -and              # 👈 copy
-                   $_.Name -notmatch '(?i)\bbackup\b' -and            # 👈 backup
-                   $_.Name -notmatch '\.bak($|\.)'                    # 👈 .bak
-                 } | ForEach-Object FullName
-
-          $changed = @()
-          if ('${{ github.event_name }}' -eq 'pull_request') {
-            $base='${{ github.event.pull_request.base.sha }}'
-            $head='${{ github.event.pull_request.head.sha }}'
-            $changed = (git diff --name-only $base $head) |
-                       Where-Object { $_ -match '\.(ps1|psm1|psd1)$' } |
-                       ForEach-Object { (Resolve-Path $_).Path }
+          # PSResourceGet 우선 (v3)
+          if (Get-Command Install-PSResource -ErrorAction SilentlyContinue) {
+            if (-not (Get-PSResourceRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+              Register-PSResourceRepository -Name PSGallery -Uri 'https://www.powershellgallery.com/api/v3' -Trusted
+            } else {
+              try { Set-PSResourceRepository -Name PSGallery -Trusted } catch {}
+            }
+            Install-PSResource -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -TrustRepository -Quiet -Reinstall
           }
+          else {
+            # PowerShellGet v2 폴백
+            if ($IsWindows -and -not (Get-PackageProvider -Name NuGet -ErrorAction SilentlyContinue)) {
+              Install-PackageProvider -Name NuGet -Force -Scope CurrentUser | Out-Null
+            }
+            $pg = Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue
+            if (-not $pg) {
+              $hasDefault = (Get-Command Register-PSRepository).Parameters.ContainsKey('Default')
+              if ($hasDefault) {
+                Register-PSRepository -Default
+                try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted } catch {}
+              } else {
+                Register-PSRepository -Name PSGallery `
+                  -SourceLocation 'https://www.powershellgallery.com/api/v2' `
+                  -ScriptSourceLocation 'https://www.powershellgallery.com/api/v2' `
+                  -InstallationPolicy Trusted
+              }
+            } else {
+              try { Set-PSRepository -Name PSGallery -InstallationPolicy Trusted } catch {}
+            }
+            Install-Module PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -Force -AcceptLicense
+          }
+          Import-Module PSScriptAnalyzer -Force
+          Get-Module PSScriptAnalyzer | Format-List Name,Version | Out-String | Write-Host
 
-          $mode='${{ steps.cfg.outputs.mode }}'
-          if ($mode -eq 'soft' -and $changed.Count -gt 0) { $targets = $changed } else { $targets = $all }
-
-          if (-not $targets -or $targets.Count -eq 0) {
-            "count=0" | Out-File $env:GITHUB_OUTPUT -Append
-            "# PSScriptAnalyzer Summary`n- Mode: $mode`n- Targets: 0 (skipped)" | Out-File $env:GITHUB_STEP_SUMMARY -Append
+      - name: Run analyzer and save findings
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path 'scripts/g5')) {
+            Write-Host 'No scripts/g5 directory; nothing to analyze.'
             exit 0
           }
-
-          [string[]]$targets | Set-Content targets.txt -Encoding utf8
-          "count=$($targets.Count)" | Out-File $env:GITHUB_OUTPUT -Append
-
-
-      - name: Install PSScriptAnalyzer
-        shell: pwsh
-        run: |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
-
-      - name: Run analyzer (per-file → SARIF, robust)
-        id: scan
-        if: steps.files.outputs.count != '0'
-        shell: pwsh
-        run: |
-          # 1) settings.psd1: 레포 루트 고정
-          $settings = Join-Path $env:GITHUB_WORKSPACE 'settings.psd1'
-          if (-not (Test-Path $settings)) { $settings = '' }
-          if ($settings) { Write-Host "Settings: $settings" }  # 확인용
-
-          # 대상 목록
-          [string[]]$targets = Get-Content targets.txt | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
-
-          # 리포 루트 기준 상대경로 + URI 인코딩 함수
-          $root = (Resolve-Path $env:GITHUB_WORKSPACE).Path.TrimEnd('\','/')
-          function Encode-UriPath([string]$rel) {
-            $rel = $rel -replace '\\','/'
-            $seg = $rel -split '/'
-            return ($seg | ForEach-Object { [System.Uri]::EscapeDataString($_) }) -join '/'
+          $results = Invoke-ScriptAnalyzer -Path 'scripts/g5' -Recurse -Severity Error,Warning
+          if ($results) {
+            New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+            $results | Sort-Object Severity, RuleName |
+              Select-Object Severity, RuleName, ScriptName, Line, Message |
+              Format-Table -AutoSize | Out-String | Tee-Object -FilePath 'artifacts/pssa-findings.txt'
+          } else {
+            Write-Host 'PSScriptAnalyzer: no findings'
+          }
+          # 에러가 있으면 실패 처리, 경고만 있으면 통과
+          $errCount = ($results | Where-Object { $_.Severity -eq 'Error' }).Count
+          if ($errCount -gt 0) {
+            Write-Error "PSScriptAnalyzer errors: $errCount"
           }
 
-          $all = @()
-          foreach ($t in $targets) {
-            $p = @{ Path=$t; Recurse=$true; Severity=@('Error','Warning'); Verbose=$false }
-            if ($settings) { $p['Settings'] = $settings }
-
-            $r = Invoke-ScriptAnalyzer @p
-            foreach ($i in $r) {
-              # 경로 → 상대경로
-              $abs = (Resolve-Path $i.ScriptPath).Path
-              $rel = $abs.StartsWith($root) ? $abs.Substring($root.Length).TrimStart('\','/') : $abs
-              $uri = Encode-UriPath $rel
-
-              # 2) 줄 번호: 없거나 null이면 region 생략(또는 1로 보정)
-              $loc = @{
-                physicalLocation = @{
-                  artifactLocation = @{ uri = $uri }
-                }
-              }
-              if ($i.PSObject.Properties.Name -contains 'Line' -and $i.Line) {
-                $line = [int]$i.Line
-                if ($line -lt 1) { $line = 1 }
-                $loc.physicalLocation.region = @{ startLine = $line }
-              }
-
-              $all += [pscustomobject]@{
-                ruleId   = $i.RuleName
-                level    = $(if ($i.Severity -eq 'Error') {'error'} else {'warning'})
-                message  = @{ text = $i.Message }
-                locations = @($loc)
-              }
-            }
-          }
-
-          # 카운트 출력
-          $err  = ($all | Where-Object { $_.level -eq 'error'   }).Count
-          $warn = ($all | Where-Object { $_.level -eq 'warning' }).Count
-          "errors=$err"            | Out-File $env:GITHUB_OUTPUT -Append
-          "warnings=$warn"         | Out-File $env:GITHUB_OUTPUT -Append
-          "used_settings=$settings"| Out-File $env:GITHUB_OUTPUT -Append
-
-          # SARIF 직렬화(깊이 충분히) + JSON 검증
-          $pssaVer = (Get-Module PSScriptAnalyzer).Version.ToString()
-          $sarif = @{
-            version = "2.1.0"
-            runs    = @(@{
-              tool = @{ driver = @{ name = "PSScriptAnalyzer"; version = $pssaVer } }
-              results = $all
-            })
-          } | ConvertTo-Json -Depth 100
-          $sarif | Set-Content -Path results.sarif -Encoding utf8
-          Get-Content results.sarif -Raw | ConvertFrom-Json | Out-Null
-
-
-      - name: Upload SARIF (non-blocking)
-        if: steps.files.outputs.count != '0'
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Upload findings artifact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          sarif_file: results.sarif
-          category: pssa
-        continue-on-error: true
-
-      - name: Findings → Job Summary (top 100)
-        if: steps.files.outputs.count != '0'
-        shell: pwsh
-        run: |
-          $sarif = Get-Content results.sarif -Raw | ConvertFrom-Json
-          $rows = foreach ($r in $sarif.runs[0].results) {
-            $lvl = $r.level.ToUpper()
-            $rule = $r.ruleId
-            $loc = $r.locations[0].physicalLocation
-            $file = $loc.artifactLocation.uri
-            $line = $loc.region.startLine
-            "{0} | {1} | {2}:{3}" -f $lvl, $rule, $file, $line
-          }
-          if ($rows) {
-            "#### PSScriptAnalyzer Findings (level | rule | file:line)" | Out-File $env:GITHUB_STEP_SUMMARY -Append
-            $rows | Sort-Object | Select-Object -First 100 | ForEach-Object { "- $_" } | Out-File $env:GITHUB_STEP_SUMMARY -Append
-          }
-
-      - name: Gate (errors + optional warning threshold)
-        if: steps.files.outputs.count != '0'
-        shell: pwsh
-        run: |
-          $mode   = '${{ steps.cfg.outputs.mode }}'                  # monitor | soft | hard
-          $err    = [int]'${{ steps.scan.outputs.errors }}'
-          $warn   = [int]'${{ steps.scan.outputs.warnings }}'
-          $wth    = '${{ steps.cfg.outputs.warn_threshold }}'
-          $useSet = '${{ steps.scan.outputs.used_settings }}'
-          $fail   = $false
-          $reasons = @()
-
-          switch ($mode) {
-            'monitor' { }                                           # 항상 통과
-            'soft'    { if ($err -gt 0) { $fail = $true; $reasons += "$err error(s)" } }
-            'hard'    { if ($err -gt 0) { $fail = $true; $reasons += "$err error(s)" } } # 경고는 임계치로만
-          }
-          if ($wth -and ($warn -gt [int]$wth)) {
-            $fail = $true; $reasons += "warnings $warn > threshold $wth"
-          }
-
-          $count = [int]'${{ steps.files.outputs.count }}'
-          $summary = @()
-          $summary += "### PSScriptAnalyzer Summary"
-          $summary += "- Mode: $mode"
-          $summary += "- Targets: $count"
-          $summary += "- Settings: " + ($(if ($useSet) { $useSet } else { '(default)' }))
-          $summary += "- Errors: $err"
-          $summary += "- Warnings: $warn"
-          if ($wth) { $summary += "- Warn threshold: $wth" }
-          $summary += "- Gate: " + ($(if ($fail) { "❌ FAIL ($($reasons -join '; '))" } else { "✅ PASS" }))
-          $summary -join "`n" | Out-File $env:GITHUB_STEP_SUMMARY -Append
-
-          if ($fail) { throw "PSScriptAnalyzer gate failed: $($reasons -join '; ')." }
+          name: pssa-findings
+          path: artifacts/pssa-findings.txt
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
# ========================================================= # 파일 용도 : PowerShell 스크립트 정적 점검(PSScriptAnalyzer) 전용 워크플로 # 동작 방식 : PR 또는 수동 실행 시 scripts/g5 하위의 .ps1/.psm1 등을 검사 # 연관 파일 : scripts/g5/*  .github/workflows/ak-selftest.yml (보완용) # 안전 가드 : PSResourceGet 우선 설치 → 미존재 시 PowerShellGet(v2) 폴백
#             Windows/Ubuntu 공통 동작, 설치 실패시 즉시 실패
# 산출물    : 콘솔 요약, artifacts/pssa-findings.txt (있을 경우)
# =========================================================

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
