### PR TITLE
Update post-release-canary.yml

### DIFF
--- a/.github/workflows/post-release-canary.yml
+++ b/.github/workflows/post-release-canary.yml
@@ -44,15 +44,22 @@ jobs:
           # 표준 종료코드: 0=성공, 그 외는 실패로 처리
           pwsh -NoProfile -File ops/canary-postrelease.ps1
 
-      - name: Create incident issue on failure
+      - name: Create incident issue on failure (robust)
         if: steps.canary.outcome != 'success'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}     # gh 인증 토큰
         run: |
-          $title = "Post-release canary failed"
+          # 제목/본문: PowerShell Here-String 사용(따옴표/콜론/줄바꿈 안전)
+          $title = 'Post-release canary failed'
           $body  = @"
 자동 카나리 실패: /health 응답 실패 또는 비정상.
-권고: 즉시 점검 후 URS 롤백(예:ops/urs-rollback.ps1 -Mode prev) 수행.
-trace: run=${env:GITHUB_RUN_ID} attempt=${env:GITHUB_RUN_ATTEMPT}
+권고: 즉시 점검 후 URS 롤백(예: ops/urs-rollback.ps1 -Mode prev) 수행.
+trace: run=$env:GITHUB_RUN_ID attempt=$env:GITHUB_RUN_ATTEMPT
 "@
-          gh issue create -t $title -b $body -l incident,canary
+
+          # ✅ 템플릿 YAML 파싱을 건드리지 않기 위해 REST API로 직접 생성
+          gh api --method POST "repos/$env:GITHUB_REPOSITORY/issues" `
+            -f "title=$title" `
+            -f "body=$body" `
+            -f 'labels=["incident","canary"]' | Out-Null
+


### PR DESCRIPTION
# 파일: .github/workflows/post-release-canary.yml
# 목적: 릴리즈(Publish) 직후 또는 외부 배포 신호(repository_dispatch: deploy) 이후
#       프로덕트 헬스(/health 등)를 빠르게 확인하는 "포스트 릴리즈 카나리".
#       실패 시 자동으로 Incident 이슈를 생성하여 신속 대응을 유도.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
