### PR TITLE
Update housekeeping-smoke.yml

### DIFF
--- a/.github/workflows/housekeeping-smoke.yml
+++ b/.github/workflows/housekeeping-smoke.yml
@@ -1,52 +1,141 @@
-# NO-SHELL
+# .github/workflows/housekeeping-smoke.yml
+# 목적: 주간/수동/PR 트리거로 하우스키핑 스모크 실행 → 요약을 PR(또는 고정 이슈)에 코멘트, 아티팩트/Job Summary로도 보존.
+
 name: housekeeping-smoke
+
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 18 * * 6"   # Sun 03:00 KST (Sat 18:00 UTC)
+    - cron: '0 18 * * 6'             # 매주 토요일 18:00 UTC (= 일요일 03:00 KST)
   pull_request:
     paths:
-      - "scripts/g5/**"
-      - ".github/workflows/housekeeping-smoke.yml"
+      - scripts/g5/**
+      - .github/workflows/housekeeping-smoke.yml
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: post-hk-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: pwsh
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup PowerShell 7
-        with:
-          version: "7.4.4"
-      - name: Dry-run housekeeping weekly
-        shell: pwsh
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run housekeeping smoke
+        id: smoke
+        continue-on-error: true
         run: |
-          pwsh -NoLogo -NoProfile -File "scripts/g5/housekeeping-weekly.ps1" -Root . -TimeoutSec 60 -InactivitySec 20
-      - name: Summarize logs
-        shell: pwsh
-        run: |
-          pwsh -NoLogo -NoProfile -File "scripts/g5/housekeeping-summarize.ps1"
-      - name: Upload logs + summary
+          $ErrorActionPreference = 'Stop'
+          $summary = "housekeeping-summary.md"
+
+          if (Test-Path "scripts/g5/housekeeping-smoke.ps1") {
+            try {
+              $sw = [System.Diagnostics.Stopwatch]::StartNew()
+              & pwsh -NoProfile -File "scripts/g5/housekeeping-smoke.ps1"
+              $exit = $LASTEXITCODE
+              $sw.Stop()
+              $status = if ($exit -eq 0) { 'OK' } else { "FAIL($exit)" }
+              "# Housekeeping Smoke Result" | Out-File $summary -Encoding UTF8
+              ""                            | Out-File $summary -Append
+              "* Status*: **$status**"      | Out-File $summary -Append
+              "* Duration*: ${($sw.Elapsed.TotalSeconds).ToString('0.000')}s" | Out-File $summary -Append
+              exit $exit
+            }
+            catch {
+              "# Housekeeping Smoke Result" | Out-File $summary -Encoding UTF8
+              ""                            | Out-File $summary -Append
+              "* Status*: **EXCEPTION**"    | Out-File $summary -Append
+              "* Error*: $($_.Exception.Message)" | Out-File $summary -Append
+              exit 1
+            }
+          }
+          else {
+            "# Housekeeping Smoke Result" | Out-File $summary -Encoding UTF8
+            ""                            | Out-File $summary -Append
+            "* Status*: **SKIPPED**"      | Out-File $summary -Append
+            "* Note*: scripts/g5/housekeeping-smoke.ps1 not found." | Out-File $summary -Append
+            exit 0
+          }
+
+      - name: Upload summary artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: housekeeping-artifacts
-          path: |
-            logs/apply-log.jsonl
-            housekeeping-summary.md
-          if-no-files-found: warn
-      - name: PR comment (sticky)
-        if: ${{ github.event_name == 'pull_request' }}
+          name: housekeeping-smoke-summary
+          path: housekeeping-summary.md
+          retention-days: 14
+
+      - name: Write job summary
+        if: always()
+        run: |
+          if (Test-Path 'housekeeping-summary.md') {
+            Get-Content 'housekeeping-summary.md' -Raw | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+          } else {
+            "No summary file." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+          }
+
+      - name: Post or update summary comment
+        if: always()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const body = fs.existsSync('housekeeping-summary.md') ? fs.readFileSync('housekeeping-summary.md','utf8') : '_No summary file_';
-            const header = '<!-- hk-summary -->';
-            const newBody = header + '\n' + body;
             const {owner, repo} = context.repo;
-            const issue_number = context.issue.number;
-            const existing = await github.rest.issues.listComments({owner, repo, issue_number});
-            const prev = existing.data.find(c => c.user.type !== 'Bot' ? false : (c.body||'').includes(header));
+            const pr = context.payload.pull_request || null;
+
+            // 포크 PR이면 토큰이 read-only → 코멘트 스킵
+            const isForkPR = !!pr && pr.head && pr.head.repo && pr.head.repo.fork === true;
+            if (isForkPR) {
+              core.notice('Fork PR detected -> skip commenting (token is read-only). See Job Summary & Artifact.');
+              return;
+            }
+
+            const header = '<!-- hk-summary -->';
+            const body = fs.existsSync('housekeeping-summary.md')
+              ? fs.readFileSync('housekeeping-summary.md','utf8')
+              : '_No summary file_';
+            const newBody = `${header}\n${body}`;
+
+            let issue_number = pr ? pr.number : null;
+
+            // 스케줄/수동 실행: 고정 이슈(제목) 생성/탐색 후 갱신
+            if (!issue_number) {
+              const title = 'Housekeeping Smoke Report';
+              const { data: issues } = await github.rest.issues.listForRepo({
+                owner, repo, state: 'open', labels: 'housekeeping',
+              });
+              const found = issues.find(i => i.title === title);
+              if (found) {
+                issue_number = found.number;
+              } else {
+                const created = await github.rest.issues.create({
+                  owner, repo, title,
+                  labels: ['housekeeping','automation']
+                });
+                issue_number = created.data.number;
+              }
+            }
+
+            // 헤더가 있는 기존 코멘트는 업데이트, 없으면 신규 작성
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100
+            });
+            const prev = comments.find(c => (c.user?.type === 'Bot') && (c.body||'').includes(header));
             if (prev) {
-              await github.rest.issues.updateComment({owner, repo, comment_id: prev.id, body: newBody});
+              await github.rest.issues.updateComment({ owner, repo, comment_id: prev.id, body: newBody });
             } else {
-              await github.rest.issues.createComment({owner, repo, issue_number, body: newBody});
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: newBody });
             }


### PR DESCRIPTION
# .github/workflows/housekeeping-smoke.yml
# 목적: 주간/수동/PR 트리거로 하우스키핑 스모크 실행 → 요약을 PR(또는 고정 이슈)에 코멘트, 아티팩트/Job Summary로도 보존.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
