### PR TITLE
Update housekeeping-smoke.yml

### DIFF
--- a/.github/workflows/housekeeping-smoke.yml
+++ b/.github/workflows/housekeeping-smoke.yml
@@ -1,22 +1,27 @@
-# .github/workflows/housekeeping-smoke.yml
-# 목적: 주간/수동/PR 트리거로 하우스키핑 스모크 실행 → 요약을 PR(또는 고정 이슈)에 코멘트, 아티팩트/Job Summary로도 보존.
+# 파일: .github/workflows/housekeeping-smoke.yml
+# 목적: 주간/수동/PR 트리거로 하우스키핑 스모크 실행 → 결과를
+#       ① PR 코멘트(같은 레포 PR) 또는 ② 고정 이슈(스케줄/수동)로 게시.
+#       항상 아티팩트와 Job Summary에도 남김.
+# 주의: 들여쓰기 2스페이스, 탭 금지.
 
 name: housekeeping-smoke
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   schedule:
-    - cron: '0 18 * * 6'             # 매주 토요일 18:00 UTC (= 일요일 03:00 KST)
+    - cron: '0 18 * * 6'          # 매주 토요일 18:00 UTC (= 일요일 03:00 KST)
   pull_request:
     paths:
       - scripts/g5/**
       - .github/workflows/housekeeping-smoke.yml
 
+# 최소 권한 + PR 코멘트 안정성
 permissions:
   contents: read
   issues: write
   pull-requests: write
 
+# 동일 ref 중복 실행 방지
 concurrency:
   group: post-hk-smoke-${{ github.ref }}
   cancel-in-progress: true
@@ -33,42 +38,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # 스모크 스크립트 실행 → 요약 MD 파일을 스크립트가 직접 생성
       - name: Run housekeeping smoke
         id: smoke
-        continue-on-error: true
+        continue-on-error: true            # 실패해도 보고 스텝은 실행
         run: |
           $ErrorActionPreference = 'Stop'
           $summary = "housekeeping-summary.md"
 
+          $sw = [System.Diagnostics.Stopwatch]::StartNew()
           if (Test-Path "scripts/g5/housekeeping-smoke.ps1") {
-            try {
-              $sw = [System.Diagnostics.Stopwatch]::StartNew()
-              & pwsh -NoProfile -File "scripts/g5/housekeeping-smoke.ps1"
-              $exit = $LASTEXITCODE
-              $sw.Stop()
-              $status = if ($exit -eq 0) { 'OK' } else { "FAIL($exit)" }
-              "# Housekeeping Smoke Result" | Out-File $summary -Encoding UTF8
-              ""                            | Out-File $summary -Append
-              "* Status*: **$status**"      | Out-File $summary -Append
-              "* Duration*: ${($sw.Elapsed.TotalSeconds).ToString('0.000')}s" | Out-File $summary -Append
-              exit $exit
-            }
-            catch {
-              "# Housekeeping Smoke Result" | Out-File $summary -Encoding UTF8
-              ""                            | Out-File $summary -Append
-              "* Status*: **EXCEPTION**"    | Out-File $summary -Append
-              "* Error*: $($_.Exception.Message)" | Out-File $summary -Append
-              exit 1
-            }
+            & pwsh -NoProfile -File "scripts/g5/housekeeping-smoke.ps1" -SummaryPath $summary
+            $exit = $LASTEXITCODE
+          } else {
+            "# Housekeeping Smoke" | Out-File $summary -Encoding UTF8
+            "" | Out-File $summary -Append
+            "| Check | Status | Message | Duration(ms) |" | Out-File $summary -Append
+            "|---|---|---|---:|" | Out-File $summary -Append
+            "| script | SKIPPED | scripts/g5/housekeeping-smoke.ps1 not found | 0 |" | Out-File $summary -Append
+            $exit = 0
           }
-          else {
-            "# Housekeeping Smoke Result" | Out-File $summary -Encoding UTF8
-            ""                            | Out-File $summary -Append
-            "* Status*: **SKIPPED**"      | Out-File $summary -Append
-            "* Note*: scripts/g5/housekeeping-smoke.ps1 not found." | Out-File $summary -Append
-            exit 0
-          }
+          $sw.Stop()
+          "" | Out-File $summary -Append
+          "**Exit**: $exit" | Out-File $summary -Append
+          "**Duration(s)**: ${($sw.Elapsed.TotalSeconds).ToString('0.000')}" | Out-File $summary -Append
+          exit $exit
 
+      # 산출물 보존(항상)
       - name: Upload summary artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -77,6 +73,7 @@ jobs:
           path: housekeeping-summary.md
           retention-days: 14
 
+      # Job Summary에도 그대로 노출(항상)
       - name: Write job summary
         if: always()
         run: |
@@ -86,32 +83,34 @@ jobs:
             "No summary file." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
           }
 
+      # PR이면 PR 코멘트, 스케줄/수동이면 고정 이슈에 코멘트(헤더 마커로 업데이트)
       - name: Post or update summary comment
         if: always()
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const core = require('@actions/core');
             const fs = require('fs');
             const {owner, repo} = context.repo;
             const pr = context.payload.pull_request || null;
 
-            // 포크 PR이면 토큰이 read-only → 코멘트 스킵
+            // 포크에서 온 PR은 토큰이 read-only → 코멘트 스킵
             const isForkPR = !!pr && pr.head && pr.head.repo && pr.head.repo.fork === true;
             if (isForkPR) {
-              core.notice('Fork PR detected -> skip commenting (token is read-only). See Job Summary & Artifact.');
+              core.notice('Fork PR detected → skip commenting (token read-only). Check Job Summary & Artifact.');
               return;
             }
 
             const header = '<!-- hk-summary -->';
             const body = fs.existsSync('housekeeping-summary.md')
-              ? fs.readFileSync('housekeeping-summary.md','utf8')
+              ? fs.readFileSync('housekeeping-summary.md', 'utf8')
               : '_No summary file_';
             const newBody = `${header}\n${body}`;
 
             let issue_number = pr ? pr.number : null;
 
-            // 스케줄/수동 실행: 고정 이슈(제목) 생성/탐색 후 갱신
+            // 스케줄/수동 실행 시: 고정 이슈(제목) 생성/탐색
             if (!issue_number) {
               const title = 'Housekeeping Smoke Report';
               const { data: issues } = await github.rest.issues.listForRepo({
@@ -129,11 +128,11 @@ jobs:
               }
             }
 
-            // 헤더가 있는 기존 코멘트는 업데이트, 없으면 신규 작성
+            // 기존 봇 코멘트(헤더 포함) 있으면 업데이트, 없으면 신규
             const { data: comments } = await github.rest.issues.listComments({
               owner, repo, issue_number, per_page: 100
             });
-            const prev = comments.find(c => (c.user?.type === 'Bot') && (c.body||'').includes(header));
+            const prev = comments.find(c => (c.user?.type === 'Bot') && (c.body || '').includes(header));
             if (prev) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: prev.id, body: newBody });
             } else {


### PR DESCRIPTION
# 파일: .github/workflows/housekeeping-smoke.yml
# 목적: 주간/수동/PR 트리거로 하우스키핑 스모크 실행 → 결과를
#       ① PR 코멘트(같은 레포 PR) 또는 ② 고정 이슈(스케줄/수동)로 게시.
#       항상 아티팩트와 Job Summary에도 남김.
# 주의: 들여쓰기 2스페이스, 탭 금지.

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
