### PR TITLE
Update ak-run.yml

### DIFF
--- a/.github/workflows/ak-run.yml
+++ b/.github/workflows/ak-run.yml
@@ -1,52 +1,170 @@
-name: AK7 run (/ak only, robust)
+# ===========================================
+# 파일: .github/workflows/ak-run.yml
+# 목적: 이슈/PR 댓글에서 "/ak ..." 명령을 감지하여
+#       디스패처 워크플로(ak-dispatch.yml)를 안전하게 호출하는 게이트웨이.
+# 핵심:
+#   - issue_comment(created) 트리거
+#   - 작성자 권한 가드(OWNER/MEMBER/COLLABORATOR만 허용)
+#   - PR인 경우 헤드 SHA/브랜치 추출 → 디스패처에 정확히 전달
+#   - 동시성/취소/타임아웃/권한 최소화/요약/아티팩트
+# 참고:
+#   - 실제 /ak 명령 실행(스캔/수정 등)은 ak-dispatch.yml + scripts/g5/ak-dispatch.ps1에서 수행
+# ===========================================
+
+name: AK run (/ak comment gateway)
 
 on:
   issue_comment:
-    types: [created]
+    types: [created]    # 댓글이 새로 달릴 때만 반응
 
 permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: write        # 동일 저장소 내 workflow_dispatch 호출(createWorkflowDispatch)에 필요
+
+# 동일 이슈에서 중복 호출 시, 최신 실행만 유지
+concurrency:
+  group: ak-run-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   ak:
-    if: startsWith(github.event.comment.body, '/ak')
+    # 1차 필터: 댓글 본문이 "/ak"로 시작하는지(공백 대비를 위해 아래 스크립트에서 2차 확인도 수행)
+    if: ${{ startsWith(github.event.comment.body, '/ak') || startsWith(trim(github.event.comment.body), '/ak') }}
     runs-on: windows-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
-      - name: ack
+      - name: Checkout (shallow)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # 컨텍스트 추출 + 권한 가드 + PR 헤드 정보 확보
+      - name: Extract context & guard
+        id: ctx
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const body = context.payload.comment.body.trim();
-            await github.rest.issues.createComment({
+            // == 입력/컨텍스트 파싱 ==
+            const bodyRaw = context.payload.comment?.body ?? "";
+            const body = bodyRaw.trim();
+            const firstLine = body.split(/\r?\n/)[0];   // "/ak ..." 명령은 보통 1행
+            const isAK = firstLine.toLowerCase().startsWith('/ak');
+
+            // == 작성자 권한 가드 ==
+            // OWNER/MEMBER/COLLABORATOR만 허용(공개 저장소 남용 방지)
+            const assoc = context.payload.comment?.author_association ?? "NONE";
+            const allowed = ["OWNER","MEMBER","COLLABORATOR"].includes(assoc);
+
+            // == PR 여부/번호 ==
+            const isPR = !!context.payload.issue?.pull_request;
+            let pr = isPR ? context.payload.issue.number : 0;
+
+            // == ref/sha (PR이면 헤드 기준으로 교체) ==
+            let ref = context.ref;
+            let headSha = context.sha;
+            if (isPR) {
+              const { data: prdata } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr
+              });
+              ref = prdata.head.ref;
+              headSha = prdata.head.sha;
+            }
+
+            // == 결과 출력(다음 스텝에서 사용) ==
+            core.setOutput('is_ak', isAK ? '1' : '0');
+            core.setOutput('allowed', allowed ? '1' : '0');
+            core.setOutput('assoc', assoc);
+            core.setOutput('first', firstLine);
+            core.setOutput('is_pr', isPR ? '1' : '0');
+            core.setOutput('pr', String(pr));
+            core.setOutput('ref', ref);
+            core.setOutput('sha', headSha);
+
+      # 허용되지 않은 작성자/형태면 여기서 친절히 종료
+      - name: Short-circuit (skip unauthorized or non-/ak)
+        if: ${{ steps.ctx.outputs.is_ak != '1' || steps.ctx.outputs.allowed != '1' }}
+        run: |
+          $lines = @()
+          $lines += '### AK Run — skipped'
+          $lines += ("- **isAK**    : {0}" -f '${{ steps.ctx.outputs.is_ak }}')
+          $lines += ("- **allowed** : {0} (author_association=`${{ steps.ctx.outputs.assoc }}`)" -f '${{ steps.ctx.outputs.allowed }}')
+          $lines += ("- **reason**  : not an `/ak` comment or unauthorized author")
+          ($lines -join "`n") | Out-File -FilePath xp-summary.md -Encoding utf8
+          Get-Content xp-summary.md -Raw | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
+      # 디스패처 호출: ak-dispatch.yml 에 workflow_dispatch 이벤트 발생
+      - name: Dispatch ak-dispatch (workflow_dispatch)
+        if: ${{ steps.ctx.outputs.is_ak == '1' && steps.ctx.outputs.allowed == '1' }}
+        uses: actions/github-script@v7
+        env:
+          WREF:  ${{ steps.ctx.outputs.ref }}
+          WPR:   ${{ steps.ctx.outputs.pr }}
+          WSHA:  ${{ steps.ctx.outputs.sha }}
+          WCMD:  ${{ steps.ctx.outputs.first }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // 동일 저장소의 워크플로 파일 경로(파일명 바뀌었으면 수정)
+            const workflow_id = '.github/workflows/ak-dispatch.yml';
+
+            const inputs = {
+              cmd:  process.env.WCMD,   // "/ak scan" 같은 원문
+              pr:   process.env.WPR,    // PR 번호(이슈면 '0')
+              sha:  process.env.WSHA    // PR이면 head SHA, 아니면 현재 SHA
+            };
+
+            // 워크플로 디스패치
+            await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `ack ✅ "${body}"`
+              workflow_id,
+              ref: process.env.WREF,    // PR이면 head 브랜치, 아니면 현재 ref
+              inputs
             });
 
-      - name: make summary
-        shell: pwsh
-        run: |
-          $BODY = "${{ github.event.comment.body }}".Trim()
-          $IS_PR = "${{ github.event.issue.pull_request.url || '' }}".Length -gt 0
-          $ISSUE = "${{ github.event.issue.number }}"
-          "# gate`n"                       | Out-File -FilePath xp-summary.md -Encoding utf8
-          "event | issue_comment"          | Out-File -Append xp-summary.md
-          "isAK  | 1"                      | Out-File -Append xp-summary.md
-          "issue | $ISSUE"                 | Out-File -Append xp-summary.md
-          "body  | $BODY"                  | Out-File -Append xp-summary.md
-          ""                               | Out-File -Append xp-summary.md
-          "# pr`n"                         | Out-File -Append xp-summary.md
-          "isPR | $([int]$IS_PR)"          | Out-File -Append xp-summary.md
-          echo "## gate"                   >> $env:GITHUB_STEP_SUMMARY
-          type xp-summary.md               >> $env:GITHUB_STEP_SUMMARY
+            core.notice(`Dispatched '${workflow_id}' on ref='${process.env.WREF}' with inputs ${JSON.stringify(inputs)}`);
 
-      - name: upload xp-summary
+      # 실행 요약 출력
+      - name: Write job summary
+        if: always()
+        run: |
+          $cmd   = '${{ steps.ctx.outputs.first }}'
+          $who   = '${{ github.actor }}'
+          $assoc = '${{ steps.ctx.outputs.assoc }}'
+          $ispr  = '${{ steps.ctx.outputs.is_pr }}'
+          $pr    = '${{ steps.ctx.outputs.pr }}'
+          $sha   = '${{ steps.ctx.outputs.sha }}'
+          $ref   = '${{ steps.ctx.outputs.ref }}'
+          $ok    = '${{ steps.ctx.outputs.is_ak }}' -eq '1' -and '${{ steps.ctx.outputs.allowed }}' -eq '1'
+
+          $lines = @()
+          $lines += '### AK Run — gateway summary'
+          $lines += ("- **cmd**   : `{0}`" -f $cmd)
+          $lines += ("- **actor** : `{0}` (assoc=`{1}`)" -f $who, $assoc)
+          $lines += ("- **isPR**  : {0}  **pr**: {1}" -f $ispr, $pr)
+          $lines += ("- **ref**   : `{0}`" -f $ref)
+          $lines += ("- **sha**   : `{0}`" -f $sha)
+          $lines += ("- **dispatch**: {0}" -f ($(if($ok){'sent ✅'}else{'skipped 🚫'})))
+
+          ($lines -join "`n") | Out-File -FilePath xp-summary.md -Encoding utf8
+          Get-Content xp-summary.md -Raw | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
+      # 요약 파일을 아티팩트로 보존(운영/감사 추적)
+      - name: Upload xp-summary artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: xp-summary
           path: xp-summary.md
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
# ===========================================
# 파일: .github/workflows/ak-run.yml
# 목적: 이슈/PR 댓글에서 "/ak ..." 명령을 감지하여
#       디스패처 워크플로(ak-dispatch.yml)를 안전하게 호출하는 게이트웨이.
# 핵심:
#   - issue_comment(created) 트리거
#   - 작성자 권한 가드(OWNER/MEMBER/COLLABORATOR만 허용)
#   - PR인 경우 헤드 SHA/브랜치 추출 → 디스패처에 정확히 전달
#   - 동시성/취소/타임아웃/권한 최소화/요약/아티팩트
# 참고:
#   - 실제 /ak 명령 실행(스캔/수정 등)은 ak-dispatch.yml + scripts/g5/ak-dispatch.ps1에서 수행
# ===========================================

## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
