### PR TITLE
Update klc-validate.yml 기존 KLC 야말을 “수동 전용”으로 바꾸기

### DIFF
--- a/.github/workflows/klc-validate.yml
+++ b/.github/workflows/klc-validate.yml
@@ -1,13 +1,16 @@
 name: CI · KLC v1.3 validate
 on:
-  pull_request:
-  workflow_dispatch:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
 
 jobs:
-  klc:
-    runs-on: windows-latest
+  noop:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - run: echo "Legacy KLC disabled. Use 'KLC / Nightly Aggregate v2'."
 
       - name: Emit KLC lines (make context + inventory)
         shell: pwsh


### PR DESCRIPTION
## 목적
- [ ] 버그 수정  [ ] 기능 추가  [ ] 문서/운영  [ ] 기타

## 체크
- [ ] Contracts CI 초록불
- [ ] `/ak scan` tail OK
- [ ] `/ak rewrite preview` 결과 확인
- [ ] `/ak fix` 수행(필요 시)
- [ ] `/ak test` 초록불
- [ ] 마지막 KLC 1행 붙임: `trace=____ durationMs=___ exit=___ anchor=____`
- [ ] DocsManifest/ _inventory 갱신(필요 시)
